### PR TITLE
Add VS Code tasks and launch configs for Vite workflows

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,77 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Chrome: Attach to Vite (DEV)",
+      "type": "pwa-chrome",
+      "request": "launch",
+      "url": "http://localhost:5173",
+      "webRoot": "${workspaceFolder}",
+      "timeout": 60000,
+      "sourceMaps": true,
+      "presentation": {
+        "group": "web"
+      }
+    },
+    {
+      "name": "Chrome: Attach to Preview (PROD)",
+      "type": "pwa-chrome",
+      "request": "launch",
+      "url": "http://localhost:5173",
+      "webRoot": "${workspaceFolder}",
+      "timeout": 60000,
+      "presentation": {
+        "group": "web"
+      }
+    },
+    {
+      "name": "Playwright Tests (Debug)",
+      "type": "pwa-node",
+      "request": "launch",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": [
+        "playwright",
+        "test",
+        "--debug"
+      ],
+      "env": {
+        "PWDEBUG": "1",
+        "TZ": "Australia/Brisbane"
+      },
+      "console": "integratedTerminal",
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "name": "Vitest (Watch + Inspect)",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "node",
+      "runtimeArgs": [
+        "--inspect-brk",
+        "${workspaceFolder}/node_modules/vitest/vitest.mjs",
+        "watch"
+      ],
+      "env": {
+        "TZ": "Australia/Brisbane"
+      },
+      "console": "integratedTerminal",
+      "cwd": "${workspaceFolder}"
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Dev (Vite + Chrome)",
+      "configurations": [
+        "Chrome: Attach to Vite (DEV)"
+      ],
+      "preLaunchTask": "Dev"
+    },
+    {
+      "name": "Prod Preview + Chrome",
+      "configurations": [
+        "Chrome: Attach to Preview (PROD)"
+      ],
+      "preLaunchTask": "Prod: Build + Preview"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,119 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Playwright: Install",
+      "type": "shell",
+      "command": "npx",
+      "args": [
+        "playwright",
+        "install",
+        "--with-deps"
+      ],
+      "problemMatcher": []
+    },
+    {
+      "label": "Dev",
+      "type": "npm",
+      "script": "dev",
+      "isBackground": true,
+      "problemMatcher": {
+        "owner": "vite",
+        "pattern": [
+          {
+            "regexp": "^(ERROR\\s+.*)$",
+            "message": 1
+          }
+        ],
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "^\\s*>",
+          "endsPattern": "Local:\\s+http://localhost:5173\\/?"
+        }
+      }
+    },
+    {
+      "label": "Build",
+      "type": "npm",
+      "script": "build",
+      "problemMatcher": []
+    },
+    {
+      "label": "Preview",
+      "type": "npm",
+      "script": "preview",
+      "isBackground": true,
+      "problemMatcher": {
+        "owner": "vite-preview",
+        "pattern": [
+          {
+            "regexp": "^(ERROR\\s+.*)$",
+            "message": 1
+          }
+        ],
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "^\\s*>",
+          "endsPattern": "Local:\\s+http://localhost:5173\\/?"
+        }
+      }
+    },
+    {
+      "label": "Test: Unit (CI)",
+      "type": "npm",
+      "script": "test",
+      "problemMatcher": []
+    },
+    {
+      "label": "Test: Unit (Watch)",
+      "type": "npm",
+      "script": "test:watch",
+      "problemMatcher": []
+    },
+    {
+      "label": "Test: E2E (CI)",
+      "type": "npm",
+      "script": "e2e",
+      "dependsOn": [
+        "Playwright: Install"
+      ],
+      "problemMatcher": []
+    },
+    {
+      "label": "Test: E2E (Headed)",
+      "type": "npm",
+      "script": "e2e:headed",
+      "dependsOn": [
+        "Playwright: Install"
+      ],
+      "problemMatcher": []
+    },
+    {
+      "label": "Test: All (Unit + E2E)",
+      "type": "shell",
+      "command": "date",
+      "args": [
+        "+Test pipeline started %Y-%m-%d %H:%M:%S %Z"
+      ],
+      "options": {
+        "env": {
+          "TZ": "Australia/Brisbane"
+        }
+      },
+      "dependsOn": [
+        "Test: Unit (CI)",
+        "Test: E2E (CI)"
+      ],
+      "dependsOrder": "sequence",
+      "problemMatcher": []
+    },
+    {
+      "label": "Prod: Build + Preview",
+      "dependsOn": [
+        "Build",
+        "Preview"
+      ],
+      "dependsOrder": "sequence"
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "shift-recorder",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@heroicons/react": "2.1.5",
         "@tanstack/react-query": "5.62.7",
@@ -19,6 +20,7 @@
         "vite-plugin-pwa": "0.20.5"
       },
       "devDependencies": {
+        "@playwright/test": "1.49.0",
         "@testing-library/jest-dom": "6.6.3",
         "@testing-library/react": "16.1.0",
         "@testing-library/user-event": "14.5.2",
@@ -2335,6 +2337,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.0.tgz",
+      "integrity": "sha512-DMulbwQURa8rNIQrf94+jPJQ4FmOVdpE5ZppRNvWVjvhC+6sOeo28r8MgIpQRYouXRtt/FCCXU7zn20jnHR4Qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.49.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@remix-run/router": {
@@ -7426,6 +7444,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
+      "integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.49.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
+      "integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -6,11 +6,15 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview",
-    "test": "vitest",
-    "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "preview": "vite preview --strictPort --port 5173",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "e2e": "playwright test",
+    "e2e:headed": "playwright test --headed",
+    "lint": "eslint .",
     "format": "prettier --write .",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "postinstall": "playwright install"
   },
   "dependencies": {
     "@heroicons/react": "2.1.5",
@@ -24,6 +28,7 @@
     "vite-plugin-pwa": "0.20.5"
   },
   "devDependencies": {
+    "@playwright/test": "1.49.0",
     "@testing-library/jest-dom": "6.6.3",
     "@testing-library/react": "16.1.0",
     "@testing-library/user-event": "14.5.2",


### PR DESCRIPTION
## Summary
- add required npm scripts and Playwright dependency to support CI, preview, and e2e flows
- add VS Code task definitions for dev, preview, and sequential unit/e2e testing with Brisbane timestamp logging
- add VS Code launch configurations and compounds to attach Chrome to dev and preview servers plus debug Vitest and Playwright

## Testing
- npm install *(fails: Playwright browser download blocked by host permissions)*

------
https://chatgpt.com/codex/tasks/task_e_68db272e340c8331a7ae490d28f01059