### PR TITLE
Add Playwright smoke test and configuration

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = process.env.PLAYWRIGHT_PORT ?? '4173';
+const HOST = process.env.PLAYWRIGHT_HOST ?? '127.0.0.1';
+
+export default defineConfig({
+  testDir: './src/tests/e2e',
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  use: {
+    baseURL: `http://${HOST}:${PORT}`,
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: `npm run dev -- --host 0.0.0.0 --port ${PORT}`,
+    url: `http://${HOST}:${PORT}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/src/tests/e2e/smoke.spec.ts
+++ b/src/tests/e2e/smoke.spec.ts
@@ -1,7 +1,12 @@
-import { describe, it } from 'vitest';
+import { test, expect } from '@playwright/test';
 
-describe.skip('pwa smoke e2e placeholder', () => {
-  it('is pending Playwright coverage', () => {
-    // Placeholder to keep Vitest satisfied while Playwright is configured later.
+const APP_TITLE = /Shift Recorder/i;
+
+test.describe('pwa smoke test', () => {
+  test('app loads', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page).toHaveTitle(APP_TITLE);
+    await expect(page.getByRole('heading', { level: 1, name: APP_TITLE })).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- replace the Vitest placeholder with a Playwright smoke test that checks the Shift Recorder shell loads
- add a Playwright configuration so the smoke test runs against a Vite dev server

## Testing
- npm run e2e *(fails: Playwright browsers are unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db316f430483318001d7f62978eb60