### PR TITLE
Refine holiday region selection for penalty rates

### DIFF
--- a/src/app/db/schema.ts
+++ b/src/app/db/schema.ts
@@ -17,6 +17,7 @@ export type Settings = {
   penaltyAllDayWeekdays: Weekday[];
   includePublicHolidays: boolean;
   publicHolidayCountry: string;
+  publicHolidaySubdivision: string;
   publicHolidayDates: string[];
   createdAt: string;
   updatedAt: string;
@@ -48,6 +49,7 @@ export const DEFAULT_SETTINGS: Settings = {
   penaltyAllDayWeekdays: [0, 6],
   includePublicHolidays: false,
   publicHolidayCountry: 'AU',
+  publicHolidaySubdivision: '',
   publicHolidayDates: [],
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString()
@@ -85,6 +87,23 @@ function sanitizeHolidayDates(values: unknown): string[] {
   return Array.from(unique).sort();
 }
 
+function sanitizeHolidaySubdivision(value: unknown, countryCode: string): string {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const normalized = value.trim().toUpperCase();
+  if (!normalized) {
+    return '';
+  }
+  if (!normalized.startsWith(`${countryCode}-`)) {
+    return '';
+  }
+  if (!/^[A-Z]{2}-[A-Z0-9]{1,10}$/.test(normalized)) {
+    return '';
+  }
+  return normalized;
+}
+
 export function applySettingsDefaults(partial: Partial<Settings> | undefined): Settings {
   const base = partial ?? {};
   const startMinute = sanitizePenaltyMinutes(base.penaltyDailyStartMinute, DEFAULT_SETTINGS.penaltyDailyStartMinute);
@@ -104,6 +123,10 @@ export function applySettingsDefaults(partial: Partial<Settings> | undefined): S
   const publicHolidayCountry = /^[A-Z]{2}$/.test(normalizedCountry)
     ? normalizedCountry
     : DEFAULT_SETTINGS.publicHolidayCountry;
+  const publicHolidaySubdivision = sanitizeHolidaySubdivision(
+    base.publicHolidaySubdivision ?? DEFAULT_SETTINGS.publicHolidaySubdivision,
+    publicHolidayCountry
+  );
   const publicHolidayDates = sanitizeHolidayDates(base.publicHolidayDates ?? DEFAULT_SETTINGS.publicHolidayDates);
 
   return {
@@ -117,6 +140,7 @@ export function applySettingsDefaults(partial: Partial<Settings> | undefined): S
     penaltyAllDayWeekdays,
     includePublicHolidays,
     publicHolidayCountry,
+    publicHolidaySubdivision,
     publicHolidayDates,
     createdAt: base.createdAt ?? DEFAULT_SETTINGS.createdAt,
     updatedAt: base.updatedAt ?? DEFAULT_SETTINGS.updatedAt

--- a/src/app/logic/publicHolidays.ts
+++ b/src/app/logic/publicHolidays.ts
@@ -4,6 +4,19 @@ type PublicHolidayResponse = {
   date: string;
   localName: string;
   name: string;
+  counties?: string[] | null;
+};
+
+type CountryInfoResponse = {
+  countryCode: string;
+  name: string;
+  officialName?: string;
+  counties?: Array<{ code: string; name: string; shortName?: string }>;
+};
+
+export type HolidayRegion = {
+  code: string;
+  name: string;
 };
 
 function sanitizeCountryCode(code: string): string {
@@ -13,11 +26,85 @@ function sanitizeCountryCode(code: string): string {
   return code.trim().toUpperCase();
 }
 
-export async function fetchPublicHolidays(countryCode: string, years: number[]): Promise<string[]> {
+function sanitizeSubdivisionCode(subdivisionCode: string | undefined, countryCode: string): string {
+  if (!subdivisionCode) {
+    return '';
+  }
+  const normalized = subdivisionCode.trim().toUpperCase();
+  if (!normalized) {
+    return '';
+  }
+  if (!normalized.startsWith(`${countryCode}-`)) {
+    return '';
+  }
+  if (!/^[A-Z]{2}-[A-Z0-9]{1,10}$/.test(normalized)) {
+    return '';
+  }
+  return normalized;
+}
+
+function normalizeCountyCode(value: string): string {
+  return value.trim().toUpperCase();
+}
+
+export async function fetchPublicHolidayRegions(countryCode: string): Promise<HolidayRegion[]> {
   const normalizedCountry = sanitizeCountryCode(countryCode);
   if (!/^[A-Z]{2}$/.test(normalizedCountry)) {
     throw new Error('Please provide a valid two-letter country code for public holidays.');
   }
+
+  const endpoint = `${API_BASE_URL}/CountryInfo/${normalizedCountry}`;
+
+  let response: Response;
+  try {
+    response = await fetch(endpoint);
+  } catch (error) {
+    throw new Error(`Unable to reach the public holidays service (${endpoint}).`);
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to load regions for ${normalizedCountry}.`);
+  }
+
+  const data = (await response.json()) as CountryInfoResponse;
+  const counties = Array.isArray(data?.counties) ? data.counties : [];
+  const regions: HolidayRegion[] = counties
+    .map((county) => {
+      if (!county?.code || !county?.name) {
+        return null;
+      }
+      const code = county.code.trim().toUpperCase();
+      if (!code.startsWith(`${normalizedCountry}-`)) {
+        return null;
+      }
+      return {
+        code,
+        name: county.name.trim()
+      } satisfies HolidayRegion;
+    })
+    .filter((region): region is HolidayRegion => Boolean(region));
+
+  const unique = new Map<string, HolidayRegion>();
+  regions.forEach((region) => {
+    if (!unique.has(region.code)) {
+      unique.set(region.code, region);
+    }
+  });
+
+  return Array.from(unique.values()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function fetchPublicHolidays(
+  countryCode: string,
+  years: number[],
+  subdivisionCode?: string
+): Promise<string[]> {
+  const normalizedCountry = sanitizeCountryCode(countryCode);
+  if (!/^[A-Z]{2}$/.test(normalizedCountry)) {
+    throw new Error('Please provide a valid two-letter country code for public holidays.');
+  }
+
+  const normalizedSubdivision = sanitizeSubdivisionCode(subdivisionCode, normalizedCountry);
 
   const uniqueYears = Array.from(new Set(years.filter((year) => Number.isFinite(year) && year >= 1900))).sort((a, b) => a - b);
   if (uniqueYears.length === 0) {
@@ -42,7 +129,17 @@ export async function fetchPublicHolidays(countryCode: string, years: number[]):
 
     const data = (await response.json()) as PublicHolidayResponse[];
     data.forEach((holiday) => {
-      if (holiday?.date) {
+      if (!holiday?.date) {
+        return;
+      }
+
+      if (!normalizedSubdivision) {
+        holidayDates.add(holiday.date);
+        return;
+      }
+
+      const counties = Array.isArray(holiday.counties) ? holiday.counties.map(normalizeCountyCode) : [];
+      if (counties.length === 0 || counties.includes(normalizedSubdivision)) {
         holidayDates.add(holiday.date);
       }
     });

--- a/src/tests/logic/publicHolidays.test.ts
+++ b/src/tests/logic/publicHolidays.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchPublicHolidays, fetchPublicHolidayRegions } from '../../app/logic/publicHolidays';
+
+function mockFetchResponse(data: unknown, ok = true) {
+  return {
+    ok,
+    json: async () => data
+  } as unknown as Response;
+}
+
+describe('public holiday utilities', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('filters public holidays for a specific subdivision while keeping national holidays', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockFetchResponse([
+        { date: '2024-01-01', counties: null },
+        { date: '2024-03-01', counties: ['AU-NSW'] },
+        { date: '2024-04-25', counties: ['AU-ACT'] },
+        { date: '2024-06-01', counties: ['AU-NSW', 'AU-ACT'] }
+      ])
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const dates = await fetchPublicHolidays('AU', [2024], 'AU-NSW');
+    expect(fetchMock).toHaveBeenCalledWith('https://date.nager.at/api/v3/PublicHolidays/2024/AU');
+    expect(dates).toEqual(['2024-01-01', '2024-03-01', '2024-06-01']);
+  });
+
+  it('returns holidays for the whole country when subdivision is invalid', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        mockFetchResponse([
+          { date: '2024-01-01', counties: null },
+          { date: '2024-02-01', counties: ['AU-NSW'] }
+        ])
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const dates = await fetchPublicHolidays('AU', [2024], 'NSW');
+    expect(dates).toEqual(['2024-01-01', '2024-02-01']);
+  });
+
+  it('loads and sorts holiday regions for a country', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockFetchResponse({
+        countryCode: 'AU',
+        counties: [
+          { code: 'AU-VIC', name: 'Victoria' },
+          { code: 'AU-NSW', name: 'New South Wales' },
+          { code: 'AU-NSW', name: 'Duplicate NSW' },
+          { code: 'US-CA', name: 'California' }
+        ]
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const regions = await fetchPublicHolidayRegions('AU');
+    expect(fetchMock).toHaveBeenCalledWith('https://date.nager.at/api/v3/CountryInfo/AU');
+    expect(regions).toEqual([
+      { code: 'AU-NSW', name: 'New South Wales' },
+      { code: 'AU-VIC', name: 'Victoria' }
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a selectable public holiday subdivision when the chosen country has regional holidays
- filter cached public holiday data by the selected subdivision and persist the new setting
- cover the regional holiday logic with unit tests for both date filtering and region loading

## Testing
- npm run test -- src/tests/logic


------
https://chatgpt.com/codex/tasks/task_e_68db3a0dbd8c8331881e43587fe0f4a5