### PR TITLE
Remove clock in/out button

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,6 +1,6 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { BrowserRouter, NavLink, Route, Routes } from 'react-router-dom';
-import { clockIn, clockOut, getActiveShift, getSettings } from './db/repo';
+import { getSettings } from './db/repo';
 import SummaryPage from './routes/SummaryPage';
 import ShiftsPage from './routes/ShiftsPage';
 import SettingsPage from './routes/SettingsPage';
@@ -25,39 +25,11 @@ function NavigationLink({ to, label }: { to: string; label: string }) {
 
 function Layout() {
   const { settings } = useSettings();
-  const queryClient = useQueryClient();
-  const { data: activeShift, isLoading } = useQuery({
-    queryKey: ['active-shift'],
-    queryFn: getActiveShift,
-    refetchOnWindowFocus: true
-  });
-
   useQuery({
     queryKey: ['settings'],
     queryFn: getSettings,
     enabled: !settings
   });
-
-  const clockMutation = useMutation({
-    mutationFn: async () => {
-      if (!settings) {
-        throw new Error('Settings not loaded');
-      }
-      if (activeShift) {
-        return clockOut(activeShift, settings);
-      }
-      return clockIn(settings);
-    },
-    onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['active-shift'] }),
-        queryClient.invalidateQueries({ queryKey: ['shifts'] }),
-        queryClient.invalidateQueries({ queryKey: ['summary'] })
-      ]);
-    }
-  });
-
-  const clockLabel = activeShift ? 'Clock out' : 'Clock in';
 
   return (
     <div className="min-h-screen bg-slate-100 text-slate-900 dark:bg-slate-950 dark:text-slate-50">
@@ -81,14 +53,6 @@ function Layout() {
           <Route path="/settings" element={<SettingsPage />} />
         </Routes>
       </main>
-      <button
-        type="button"
-        onClick={() => clockMutation.mutate()}
-        disabled={clockMutation.isPending || isLoading || !settings}
-        className="fixed bottom-6 right-6 rounded-full bg-primary px-6 py-4 text-base font-semibold text-primary-foreground shadow-lg shadow-primary/40 transition hover:scale-[1.02] focus-visible:outline-none focus-visible:ring-2"
-      >
-        {clockMutation.isPending ? 'Saving…' : clockLabel}
-      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove the floating clock toggle button from the main layout
- clean up unused clock in/out mutation logic now that the button is gone

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db3fc922fc83319f394e78298e3c5e