### PR TITLE
feat: switch shifts page to calendar with modal forms

### DIFF
--- a/src/app/components/Modal.tsx
+++ b/src/app/components/Modal.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useId, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import { XMarkIcon } from '@heroicons/react/24/outline';
+
+export type ModalProps = {
+  isOpen: boolean;
+  title: string;
+  onClose: () => void;
+  children: ReactNode;
+};
+
+export default function Modal({ isOpen, title, onClose, children }: ModalProps) {
+  const titleId = useId();
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = originalOverflow;
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 px-4 py-8 backdrop-blur-sm">
+      <button type="button" className="absolute inset-0 cursor-default" onClick={onClose} aria-hidden="true" />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="relative z-10 w-full max-w-xl rounded-3xl border border-slate-200 bg-white p-6 shadow-xl dark:border-slate-800 dark:bg-slate-950"
+      >
+        <div className="flex items-start justify-between gap-4">
+          <h2 id={titleId} className="text-lg font-semibold text-slate-900 dark:text-slate-50">
+            {title}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full p-2 text-slate-500 transition hover:bg-slate-100 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-100"
+            aria-label="Close dialog"
+          >
+            <XMarkIcon className="h-5 w-5" aria-hidden="true" />
+          </button>
+        </div>
+        <div className="mt-6">{children}</div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/app/routes/ShiftsPage.tsx
+++ b/src/app/routes/ShiftsPage.tsx
@@ -1,6 +1,25 @@
 import { useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import ShiftCard from '../components/ShiftCard';
+import {
+  addDays,
+  addMonths,
+  differenceInCalendarDays,
+  endOfMonth,
+  endOfWeek,
+  format,
+  isSameDay,
+  isSameMonth,
+  startOfMonth,
+  startOfWeek
+} from 'date-fns';
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  PencilSquareIcon,
+  PlusIcon,
+  TrashIcon
+} from '@heroicons/react/24/outline';
+import Modal from '../components/Modal';
 import ShiftForm, { type ShiftFormValues } from '../components/ShiftForm';
 import { createShift, deleteShift, getAllShifts, updateShift } from '../db/repo';
 import type { Shift } from '../db/schema';
@@ -9,7 +28,9 @@ import { useSettings } from '../state/SettingsContext';
 export default function ShiftsPage() {
   const queryClient = useQueryClient();
   const { settings } = useSettings();
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [editingShift, setEditingShift] = useState<Shift | null>(null);
+  const [currentMonth, setCurrentMonth] = useState(() => startOfMonth(new Date()));
   const { data: shifts = [], isLoading } = useQuery({
     queryKey: ['shifts', 'all'],
     queryFn: getAllShifts,
@@ -17,6 +38,57 @@ export default function ShiftsPage() {
   });
 
   const currency = settings?.currency ?? 'USD';
+  const weekStartsOn = (settings?.weekStartsOn ?? 1) as 0 | 1;
+
+  const calendarDays = useMemo(() => {
+    const options = { weekStartsOn } as const;
+    const start = startOfWeek(startOfMonth(currentMonth), options);
+    const end = endOfWeek(endOfMonth(currentMonth), options);
+    const total = differenceInCalendarDays(end, start) + 1;
+    return Array.from({ length: total }, (_, index) => addDays(start, index));
+  }, [currentMonth, weekStartsOn]);
+
+  const weekdayLabels = useMemo(() => {
+    const options = { weekStartsOn } as const;
+    const start = startOfWeek(new Date(), options);
+    return Array.from({ length: 7 }, (_, index) => format(addDays(start, index), 'EEE'));
+  }, [weekStartsOn]);
+
+  const shiftsByDay = useMemo(() => {
+    const grouped = new Map<string, Shift[]>();
+
+    for (const shift of shifts) {
+      const key = format(new Date(shift.startISO), 'yyyy-MM-dd');
+      const existing = grouped.get(key) ?? [];
+      existing.push(shift);
+      grouped.set(key, existing);
+    }
+
+    for (const [, dayShifts] of grouped) {
+      dayShifts.sort((a, b) => new Date(a.startISO).getTime() - new Date(b.startISO).getTime());
+    }
+
+    return grouped;
+  }, [shifts]);
+
+  const timeFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(undefined, {
+        hour: '2-digit',
+        minute: '2-digit'
+      }),
+    []
+  );
+
+  const currencyFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat(undefined, {
+        style: 'currency',
+        currency,
+        maximumFractionDigits: 2
+      }),
+    [currency]
+  );
 
   const createMutation = useMutation({
     mutationFn: async (values: ShiftFormValues) => {
@@ -24,6 +96,7 @@ export default function ShiftsPage() {
       return createShift({ startISO: values.start, endISO: values.end, note: values.note }, settings);
     },
     onSuccess: async () => {
+      setIsCreateModalOpen(false);
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['shifts'] }),
         queryClient.invalidateQueries({ queryKey: ['summary'] })
@@ -48,6 +121,7 @@ export default function ShiftsPage() {
   const deleteMutation = useMutation({
     mutationFn: async (shift: Shift) => deleteShift(shift.id),
     onSuccess: async () => {
+      setEditingShift(null);
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['shifts'] }),
         queryClient.invalidateQueries({ queryKey: ['summary'] }),
@@ -56,53 +130,184 @@ export default function ShiftsPage() {
     }
   });
 
-  const sortedShifts = useMemo(
-    () =>
-      [...shifts].sort((a, b) => new Date(b.startISO).getTime() - new Date(a.startISO).getTime()),
-    [shifts]
-  );
+  const now = new Date();
+  const monthLabel = format(currentMonth, 'MMMM yyyy');
 
   return (
     <section className="flex flex-col gap-6">
-      <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-        <h2 className="mb-4 text-lg font-semibold text-slate-900 dark:text-slate-50">Add a shift</h2>
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold text-slate-900 dark:text-slate-50">Shifts calendar</h1>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Review past work and plan upcoming shifts in a monthly view.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="flex items-center gap-1 rounded-full border border-slate-200 bg-white p-1 dark:border-slate-700 dark:bg-slate-900">
+            <button
+              type="button"
+              onClick={() => setCurrentMonth((month) => startOfMonth(addMonths(month, -1)))}
+              className="rounded-full p-2 text-slate-500 transition hover:bg-slate-100 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-100"
+              aria-label="Previous month"
+            >
+              <ChevronLeftIcon className="h-5 w-5" aria-hidden="true" />
+            </button>
+            <span className="min-w-[8rem] text-center text-sm font-semibold text-slate-700 dark:text-slate-200">{monthLabel}</span>
+            <button
+              type="button"
+              onClick={() => setCurrentMonth((month) => startOfMonth(addMonths(month, 1)))}
+              className="rounded-full p-2 text-slate-500 transition hover:bg-slate-100 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-100"
+              aria-label="Next month"
+            >
+              <ChevronRightIcon className="h-5 w-5" aria-hidden="true" />
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={() => setCurrentMonth(startOfMonth(new Date()))}
+            className="rounded-full border border-slate-200 px-3 py-1 text-sm font-medium text-slate-600 transition hover:border-primary hover:text-primary dark:border-slate-700 dark:text-slate-200"
+          >
+            Today
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setIsCreateModalOpen(true);
+            }}
+            className="flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow transition hover:bg-slate-900"
+          >
+            <PlusIcon className="h-5 w-5" aria-hidden="true" />
+            Add shift
+          </button>
+        </div>
+      </header>
+
+      {isLoading && <p className="text-sm text-slate-500">Loading shifts…</p>}
+
+      <div className="rounded-3xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <div className="grid grid-cols-7 gap-2 px-2 pb-2 text-xs font-medium uppercase tracking-wide text-slate-400 dark:text-slate-500">
+          {weekdayLabels.map((label) => (
+            <span key={label} className="text-center">
+              {label}
+            </span>
+          ))}
+        </div>
+        <div className="grid grid-cols-7 gap-2">
+          {calendarDays.map((day) => {
+            const dateKey = format(day, 'yyyy-MM-dd');
+            const dayShifts = shiftsByDay.get(dateKey) ?? [];
+            const inCurrentMonth = isSameMonth(day, currentMonth);
+            const isCurrentDay = isSameDay(day, new Date());
+
+            const dayNumberClasses = [
+              'flex h-8 w-8 items-center justify-center rounded-full text-sm font-semibold transition',
+              isCurrentDay
+                ? 'bg-primary text-primary-foreground shadow'
+                : inCurrentMonth
+                  ? 'text-slate-700 dark:text-slate-100'
+                  : 'text-slate-400 dark:text-slate-600'
+            ].join(' ');
+
+            return (
+              <div
+                key={dateKey}
+                className={`flex min-h-[9rem] flex-col rounded-2xl border p-2 ${
+                  inCurrentMonth
+                    ? 'border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-950'
+                    : 'border-transparent bg-slate-50 text-slate-400 dark:bg-slate-900/40 dark:text-slate-600'
+                }`}
+              >
+                <div className="flex items-center justify-between">
+                  <span className={dayNumberClasses}>{format(day, 'd')}</span>
+                </div>
+                <div className="mt-3 flex flex-col gap-2">
+                  {dayShifts.map((shift) => {
+                    const startDate = new Date(shift.startISO);
+                    const endDate = shift.endISO ? new Date(shift.endISO) : null;
+                    const upcoming = endDate ? endDate >= now : startDate >= now;
+                    const totalHours = ((shift.baseMinutes + shift.penaltyMinutes) / 60).toFixed(2);
+                    const shiftClasses = upcoming
+                      ? 'border-emerald-200 bg-emerald-100/80 text-emerald-900 dark:border-emerald-500/40 dark:bg-emerald-500/20 dark:text-emerald-100'
+                      : 'border-slate-200 bg-slate-100/80 text-slate-700 dark:border-slate-700 dark:bg-slate-800/70 dark:text-slate-200';
+
+                    return (
+                      <article
+                        key={shift.id}
+                        className={`flex flex-col gap-2 rounded-xl border px-3 py-2 text-xs shadow-sm transition ${shiftClasses}`}
+                      >
+                        <div className="flex items-start justify-between gap-2">
+                          <div className="flex flex-col">
+                            <span className="font-semibold">
+                              {timeFormatter.format(startDate)} — {endDate ? timeFormatter.format(endDate) : 'In progress'}
+                            </span>
+                            <span className="text-[0.65rem] opacity-80">
+                              {totalHours}h • {currencyFormatter.format(shift.totalPay)}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-1 self-start">
+                            <button
+                              type="button"
+                              onClick={() => setEditingShift(shift)}
+                              className="rounded-full p-1.5 text-current transition hover:bg-black/5 dark:hover:bg-white/10"
+                              aria-label="Edit shift"
+                            >
+                              <PencilSquareIcon className="h-4 w-4" aria-hidden="true" />
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => deleteMutation.mutate(shift)}
+                              className="rounded-full p-1.5 text-current transition hover:bg-black/5 dark:hover:bg-white/10"
+                              aria-label="Delete shift"
+                            >
+                              <TrashIcon className="h-4 w-4" aria-hidden="true" />
+                            </button>
+                          </div>
+                        </div>
+                        {shift.note && <p className="text-[0.65rem] leading-relaxed opacity-80">{shift.note}</p>}
+                      </article>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {!isLoading && shifts.length === 0 && (
+        <p className="text-sm text-slate-500 dark:text-slate-400">
+          No shifts logged yet. Use the “Add shift” button to start tracking your work.
+        </p>
+      )}
+
+      <Modal
+        isOpen={isCreateModalOpen}
+        onClose={() => setIsCreateModalOpen(false)}
+        title="Add a shift"
+      >
         <ShiftForm
+          key={isCreateModalOpen ? 'create-open' : 'create-closed'}
           onSubmit={async (values) => {
             await createMutation.mutateAsync(values);
           }}
+          onCancel={() => setIsCreateModalOpen(false)}
           submitLabel="Save shift"
         />
-      </div>
-      <div className="flex flex-col gap-4">
-        <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">All shifts</h2>
-        {isLoading && <p className="text-sm text-slate-500">Loading shifts…</p>}
-        {!isLoading && sortedShifts.length === 0 && <p className="text-sm text-slate-500">No shifts logged yet.</p>}
-        <div className="flex flex-col gap-4">
-          {sortedShifts.map((shift) => (
-            <div key={shift.id} className="flex flex-col gap-3">
-              {editingShift?.id === shift.id ? (
-                <div className="rounded-2xl border border-primary/30 bg-primary/5 p-5">
-                  <ShiftForm
-                    initialShift={shift}
-                    onSubmit={async (values) => {
-                      await updateMutation.mutateAsync({ shift, values });
-                    }}
-                    onCancel={() => setEditingShift(null)}
-                    submitLabel="Update shift"
-                  />
-                </div>
-              ) : (
-                <ShiftCard
-                  shift={shift}
-                  currency={currency}
-                  onEdit={() => setEditingShift(shift)}
-                  onDelete={() => deleteMutation.mutate(shift)}
-                />
-              )}
-            </div>
-          ))}
-        </div>
-      </div>
+      </Modal>
+
+      <Modal isOpen={Boolean(editingShift)} onClose={() => setEditingShift(null)} title="Edit shift">
+        {editingShift && (
+          <ShiftForm
+            key={editingShift.id}
+            initialShift={editingShift}
+            onSubmit={async (values) => {
+              await updateMutation.mutateAsync({ shift: editingShift, values });
+            }}
+            onCancel={() => setEditingShift(null)}
+            submitLabel="Update shift"
+          />
+        )}
+      </Modal>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- replace the shifts list with a navigable monthly calendar that color-codes upcoming versus completed shifts
- add a reusable modal component and use it for the add/edit shift forms triggered from a floating action button
- surface inline edit/delete controls inside each calendar day card for quick management

## Testing
- npm run test *(fails: Playwright e2e suite expects a running dev server and exits with ECONNREFUSED in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db3f6bedc4833199c9c446aa3a90e7