### PR TITLE
Add toggle for daily penalty window

### DIFF
--- a/src/app/db/repo.ts
+++ b/src/app/db/repo.ts
@@ -37,6 +37,7 @@ export async function saveSettings(partial: Partial<Settings>): Promise<Settings
           endISO: shift.endISO,
           baseRate: next.baseRate,
           penaltyRate: next.penaltyRate,
+          penaltyDailyWindowEnabled: next.penaltyDailyWindowEnabled,
           penaltyDailyStartMinute: next.penaltyDailyStartMinute,
           penaltyDailyEndMinute: next.penaltyDailyEndMinute,
           penaltyAllDayWeekdays: next.penaltyAllDayWeekdays,

--- a/src/app/db/schema.ts
+++ b/src/app/db/schema.ts
@@ -12,6 +12,7 @@ export type Settings = {
   penaltyRate: number;
   weekStartsOn: WeekStart;
   currency: string;
+  penaltyDailyWindowEnabled: boolean;
   penaltyDailyStartMinute: number;
   penaltyDailyEndMinute: number;
   penaltyAllDayWeekdays: Weekday[];
@@ -44,6 +45,7 @@ export const DEFAULT_SETTINGS: Settings = {
   penaltyRate: 35,
   weekStartsOn: 1,
   currency: 'USD',
+  penaltyDailyWindowEnabled: true,
   penaltyDailyStartMinute: 0,
   penaltyDailyEndMinute: 7 * 60,
   penaltyAllDayWeekdays: [0, 6],
@@ -106,9 +108,12 @@ function sanitizeHolidaySubdivision(value: unknown, countryCode: string): string
 
 export function applySettingsDefaults(partial: Partial<Settings> | undefined): Settings {
   const base = partial ?? {};
+  const penaltyDailyWindowEnabled = Boolean(
+    base.penaltyDailyWindowEnabled ?? DEFAULT_SETTINGS.penaltyDailyWindowEnabled
+  );
   const startMinute = sanitizePenaltyMinutes(base.penaltyDailyStartMinute, DEFAULT_SETTINGS.penaltyDailyStartMinute);
   let endMinute = sanitizePenaltyMinutes(base.penaltyDailyEndMinute, DEFAULT_SETTINGS.penaltyDailyEndMinute);
-  if (endMinute <= startMinute) {
+  if (penaltyDailyWindowEnabled && endMinute <= startMinute) {
     endMinute = DEFAULT_SETTINGS.penaltyDailyEndMinute;
   }
 
@@ -135,6 +140,7 @@ export function applySettingsDefaults(partial: Partial<Settings> | undefined): S
     penaltyRate: typeof base.penaltyRate === 'number' ? base.penaltyRate : DEFAULT_SETTINGS.penaltyRate,
     weekStartsOn: (typeof base.weekStartsOn === 'number' ? base.weekStartsOn : DEFAULT_SETTINGS.weekStartsOn) as WeekStart,
     currency: typeof base.currency === 'string' && base.currency.trim() ? base.currency : DEFAULT_SETTINGS.currency,
+    penaltyDailyWindowEnabled,
     penaltyDailyStartMinute: startMinute,
     penaltyDailyEndMinute: endMinute,
     penaltyAllDayWeekdays,
@@ -199,6 +205,7 @@ export async function upsertShift(
       endISO: input.endISO,
       baseRate: settings.baseRate,
       penaltyRate: settings.penaltyRate,
+      penaltyDailyWindowEnabled: settings.penaltyDailyWindowEnabled,
       penaltyDailyStartMinute: settings.penaltyDailyStartMinute,
       penaltyDailyEndMinute: settings.penaltyDailyEndMinute,
       penaltyAllDayWeekdays: settings.penaltyAllDayWeekdays,

--- a/src/app/logic/payRules.ts
+++ b/src/app/logic/payRules.ts
@@ -6,6 +6,7 @@ export type ComputePayInput = {
   endISO: string;
   baseRate: number;
   penaltyRate: number;
+  penaltyDailyWindowEnabled: boolean;
   penaltyDailyStartMinute: number;
   penaltyDailyEndMinute: number;
   penaltyAllDayWeekdays: number[];
@@ -40,6 +41,7 @@ export function computePayForShift({
   endISO,
   baseRate,
   penaltyRate,
+  penaltyDailyWindowEnabled,
   penaltyDailyStartMinute,
   penaltyDailyEndMinute,
   penaltyAllDayWeekdays,
@@ -54,6 +56,7 @@ export function computePayForShift({
   }
 
   const segments = splitIntoDailySegments(start, end, {
+    penaltyDailyWindowEnabled,
     penaltyDailyStartMinute,
     penaltyDailyEndMinute,
     penaltyAllDayWeekdays,

--- a/src/app/logic/splitIntervals.ts
+++ b/src/app/logic/splitIntervals.ts
@@ -8,6 +8,7 @@ export type DailySegment = {
 };
 
 export type PenaltyConfig = {
+  penaltyDailyWindowEnabled: boolean;
   penaltyDailyStartMinute: number;
   penaltyDailyEndMinute: number;
   penaltyAllDayWeekdays: number[];
@@ -33,7 +34,8 @@ export function splitIntoDailySegments(start: Date, end: Date, config: PenaltyCo
   const segments: DailySegment[] = [];
   let cursor = start;
   const publicHolidaySet = new Set(config.publicHolidayDates ?? []);
-  const hasDailyWindow = config.penaltyDailyEndMinute > config.penaltyDailyStartMinute;
+  const hasDailyWindow =
+    config.penaltyDailyWindowEnabled && config.penaltyDailyEndMinute > config.penaltyDailyStartMinute;
 
   while (cursor < end) {
     const dayStart = startOfDay(cursor);

--- a/src/app/routes/SettingsPage.tsx
+++ b/src/app/routes/SettingsPage.tsx
@@ -61,6 +61,9 @@ export default function SettingsPage() {
   const [currency, setCurrency] = useState(() => settings?.currency ?? 'USD');
   const [penaltyStartTime, setPenaltyStartTime] = useState(() => minutesToTime(settings?.penaltyDailyStartMinute ?? 0));
   const [penaltyEndTime, setPenaltyEndTime] = useState(() => minutesToTime(settings?.penaltyDailyEndMinute ?? 7 * 60));
+  const [penaltyDailyWindowEnabled, setPenaltyDailyWindowEnabled] = useState(
+    () => settings?.penaltyDailyWindowEnabled ?? true
+  );
   const [penaltyAllDayWeekdays, setPenaltyAllDayWeekdays] = useState<Weekday[]>(() => settings?.penaltyAllDayWeekdays ?? [0, 6]);
   const [includePublicHolidays, setIncludePublicHolidays] = useState(() => settings?.includePublicHolidays ?? false);
   const [publicHolidayCountry, setPublicHolidayCountry] = useState(() => settings?.publicHolidayCountry ?? 'AU');
@@ -80,6 +83,7 @@ export default function SettingsPage() {
       setPenaltyRate(settings.penaltyRate);
       setWeekStartsOn(settings.weekStartsOn);
       setCurrency(settings.currency);
+      setPenaltyDailyWindowEnabled(settings.penaltyDailyWindowEnabled);
       setPenaltyStartTime(minutesToTime(settings.penaltyDailyStartMinute));
       setPenaltyEndTime(minutesToTime(settings.penaltyDailyEndMinute));
       setPenaltyAllDayWeekdays(settings.penaltyAllDayWeekdays);
@@ -182,7 +186,7 @@ export default function SettingsPage() {
           const startMinutes = timeToMinutes(penaltyStartTime);
           const endMinutes = timeToMinutes(penaltyEndTime);
 
-          if (endMinutes <= startMinutes) {
+          if (penaltyDailyWindowEnabled && endMinutes <= startMinutes) {
             setFormError('Penalty end time must be after the start time.');
             setIsSaving(false);
             return;
@@ -224,6 +228,7 @@ export default function SettingsPage() {
               penaltyRate: Number(penaltyRate),
               weekStartsOn,
               currency,
+              penaltyDailyWindowEnabled,
               penaltyDailyStartMinute: startMinutes,
               penaltyDailyEndMinute: endMinutes,
               penaltyAllDayWeekdays: selectedDays,
@@ -293,6 +298,15 @@ export default function SettingsPage() {
         </div>
         <fieldset className="grid gap-3">
           <legend className="text-xs font-semibold uppercase text-slate-500">Penalty hours (daily window)</legend>
+          <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-200">
+            <input
+              type="checkbox"
+              checked={penaltyDailyWindowEnabled}
+              onChange={(event) => setPenaltyDailyWindowEnabled(event.target.checked)}
+              className="h-4 w-4 rounded border-slate-300 text-primary focus:ring-primary"
+            />
+            Enable a daily penalty window
+          </label>
           <div className="grid gap-4 sm:grid-cols-2">
             <label className="grid gap-1 text-sm text-slate-600 dark:text-slate-200">
               <span className="text-xs font-semibold uppercase text-slate-500">Start time</span>
@@ -300,7 +314,8 @@ export default function SettingsPage() {
                 type="time"
                 value={penaltyStartTime}
                 onChange={(event) => setPenaltyStartTime(event.target.value)}
-                className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40 dark:border-slate-700 dark:bg-slate-900"
+                disabled={!penaltyDailyWindowEnabled}
+                className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-60 dark:border-slate-700 dark:bg-slate-900"
               />
             </label>
             <label className="grid gap-1 text-sm text-slate-600 dark:text-slate-200">
@@ -309,12 +324,15 @@ export default function SettingsPage() {
                 type="time"
                 value={penaltyEndTime}
                 onChange={(event) => setPenaltyEndTime(event.target.value)}
-                className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40 dark:border-slate-700 dark:bg-slate-900"
+                disabled={!penaltyDailyWindowEnabled}
+                className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-60 dark:border-slate-700 dark:bg-slate-900"
               />
             </label>
           </div>
           <p className="text-xs text-slate-500">
-            Time range applies to every day unless the day is configured as an all-day penalty below.
+            {penaltyDailyWindowEnabled
+              ? 'Time range applies to every day unless the day is configured as an all-day penalty below.'
+              : 'When disabled, no time of day automatically attracts penalty rates.'}
           </p>
         </fieldset>
         <fieldset className="grid gap-3">

--- a/src/tests/logic/payRules.test.ts
+++ b/src/tests/logic/payRules.test.ts
@@ -4,6 +4,7 @@ import { computePayForShift } from '../../app/logic/payRules';
 const BASE_RATE = 25;
 const PENALTY_RATE = 35;
 const DEFAULT_CONFIG = {
+  penaltyDailyWindowEnabled: true,
   penaltyDailyStartMinute: 0,
   penaltyDailyEndMinute: 7 * 60,
   penaltyAllDayWeekdays: [0, 6],
@@ -63,6 +64,14 @@ describe('computePayForShift', () => {
       penaltyAllDayWeekdays: []
     });
     expect(result.penaltyMinutes).toBe(60);
+    expect(result.baseMinutes).toBe(60);
+  });
+
+  it('treats entire shift as base when daily penalty window disabled', () => {
+    const result = createShift('2024-04-02T06:30:00', '2024-04-02T07:30:00', {
+      penaltyDailyWindowEnabled: false
+    });
+    expect(result.penaltyMinutes).toBe(0);
     expect(result.baseMinutes).toBe(60);
   });
 


### PR DESCRIPTION
## Summary
- add a `penaltyDailyWindowEnabled` flag to settings defaults and persistence
- respect the new toggle throughout pay calculations and data recomputation
- expose a settings UI checkbox with disabled time inputs and add a unit test for the disabled case

## Testing
- npx vitest run src/tests/logic/payRules.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68db40eee0b88331a543295f7fe1179e