### PR TITLE
Add theme preference toggle to settings page

### DIFF
--- a/src/app/db/schema.ts
+++ b/src/app/db/schema.ts
@@ -6,12 +6,15 @@ import { getWeekKey } from '../logic/week';
 export type WeekStart = 0 | 1 | 2 | 3 | 4 | 5 | 6; // 0 Sunday through 6 Saturday
 export type Weekday = WeekStart;
 
+export type ThemePreference = 'system' | 'light' | 'dark';
+
 export type Settings = {
   id: 'singleton';
   baseRate: number;
   penaltyRate: number;
   weekStartsOn: WeekStart;
   currency: string;
+  theme: ThemePreference;
   penaltyDailyStartMinute: number;
   penaltyDailyEndMinute: number;
   penaltyAllDayWeekdays: Weekday[];
@@ -44,6 +47,7 @@ export const DEFAULT_SETTINGS: Settings = {
   penaltyRate: 35,
   weekStartsOn: 1,
   currency: 'USD',
+  theme: 'system',
   penaltyDailyStartMinute: 0,
   penaltyDailyEndMinute: 7 * 60,
   penaltyAllDayWeekdays: [0, 6],
@@ -104,6 +108,13 @@ function sanitizeHolidaySubdivision(value: unknown, countryCode: string): string
   return normalized;
 }
 
+function sanitizeTheme(value: unknown): ThemePreference {
+  if (value === 'light' || value === 'dark' || value === 'system') {
+    return value;
+  }
+  return 'system';
+}
+
 export function applySettingsDefaults(partial: Partial<Settings> | undefined): Settings {
   const base = partial ?? {};
   const startMinute = sanitizePenaltyMinutes(base.penaltyDailyStartMinute, DEFAULT_SETTINGS.penaltyDailyStartMinute);
@@ -135,6 +146,7 @@ export function applySettingsDefaults(partial: Partial<Settings> | undefined): S
     penaltyRate: typeof base.penaltyRate === 'number' ? base.penaltyRate : DEFAULT_SETTINGS.penaltyRate,
     weekStartsOn: (typeof base.weekStartsOn === 'number' ? base.weekStartsOn : DEFAULT_SETTINGS.weekStartsOn) as WeekStart,
     currency: typeof base.currency === 'string' && base.currency.trim() ? base.currency : DEFAULT_SETTINGS.currency,
+    theme: sanitizeTheme(base.theme ?? DEFAULT_SETTINGS.theme),
     penaltyDailyStartMinute: startMinute,
     penaltyDailyEndMinute: endMinute,
     penaltyAllDayWeekdays,

--- a/src/app/routes/SettingsPage.tsx
+++ b/src/app/routes/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useSettings } from '../state/SettingsContext';
-import type { WeekStart, Weekday } from '../db/schema';
+import type { ThemePreference, WeekStart, Weekday } from '../db/schema';
 import { fetchPublicHolidays, fetchPublicHolidayRegions, type HolidayRegion } from '../logic/publicHolidays';
 
 const WEEK_START_OPTIONS: Array<{ value: WeekStart; label: string }> = [
@@ -31,6 +31,12 @@ const PUBLIC_HOLIDAY_REGIONS: Array<{ code: string; label: string }> = [
   { code: 'CA', label: 'Canada' }
 ];
 
+const THEME_OPTIONS: Array<{ value: ThemePreference; label: string; description: string }> = [
+  { value: 'system', label: 'System', description: 'Match your device appearance settings.' },
+  { value: 'light', label: 'Light', description: 'Always use the light theme.' },
+  { value: 'dark', label: 'Dark', description: 'Always use the dark theme.' }
+];
+
 function minutesToTime(minutes: number): string {
   const safeMinutes = Number.isFinite(minutes) ? Math.max(0, Math.min(minutes, 24 * 60)) : 0;
   const hours = Math.floor(safeMinutes / 60)
@@ -59,6 +65,7 @@ export default function SettingsPage() {
   const [penaltyRate, setPenaltyRate] = useState(() => settings?.penaltyRate ?? 35);
   const [weekStartsOn, setWeekStartsOn] = useState<WeekStart>(() => settings?.weekStartsOn ?? 1);
   const [currency, setCurrency] = useState(() => settings?.currency ?? 'USD');
+  const [theme, setTheme] = useState<ThemePreference>(() => settings?.theme ?? 'system');
   const [penaltyStartTime, setPenaltyStartTime] = useState(() => minutesToTime(settings?.penaltyDailyStartMinute ?? 0));
   const [penaltyEndTime, setPenaltyEndTime] = useState(() => minutesToTime(settings?.penaltyDailyEndMinute ?? 7 * 60));
   const [penaltyAllDayWeekdays, setPenaltyAllDayWeekdays] = useState<Weekday[]>(() => settings?.penaltyAllDayWeekdays ?? [0, 6]);
@@ -80,6 +87,7 @@ export default function SettingsPage() {
       setPenaltyRate(settings.penaltyRate);
       setWeekStartsOn(settings.weekStartsOn);
       setCurrency(settings.currency);
+      setTheme(settings.theme ?? 'system');
       setPenaltyStartTime(minutesToTime(settings.penaltyDailyStartMinute));
       setPenaltyEndTime(minutesToTime(settings.penaltyDailyEndMinute));
       setPenaltyAllDayWeekdays(settings.penaltyAllDayWeekdays);
@@ -224,6 +232,7 @@ export default function SettingsPage() {
               penaltyRate: Number(penaltyRate),
               weekStartsOn,
               currency,
+              theme,
               penaltyDailyStartMinute: startMinutes,
               penaltyDailyEndMinute: endMinutes,
               penaltyAllDayWeekdays: selectedDays,
@@ -291,6 +300,30 @@ export default function SettingsPage() {
             maxLength={3}
           />
         </div>
+        <fieldset className="grid gap-3">
+          <legend className="text-xs font-semibold uppercase text-slate-500">Appearance</legend>
+          <div className="grid gap-2">
+            {THEME_OPTIONS.map((option) => (
+              <label
+                key={option.value}
+                className="flex items-start gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm transition hover:border-primary/60 dark:border-slate-700 dark:bg-slate-900"
+              >
+                <input
+                  type="radio"
+                  name="theme"
+                  value={option.value}
+                  checked={theme === option.value}
+                  onChange={() => setTheme(option.value)}
+                  className="mt-1 h-4 w-4 border-slate-300 text-primary focus:ring-primary"
+                />
+                <span className="flex flex-col">
+                  <span className="font-medium text-slate-700 dark:text-slate-100">{option.label}</span>
+                  <span className="text-xs text-slate-500 dark:text-slate-400">{option.description}</span>
+                </span>
+              </label>
+            ))}
+          </div>
+        </fieldset>
         <fieldset className="grid gap-3">
           <legend className="text-xs font-semibold uppercase text-slate-500">Penalty hours (daily window)</legend>
           <div className="grid gap-4 sm:grid-cols-2">

--- a/src/app/state/SettingsContext.tsx
+++ b/src/app/state/SettingsContext.tsx
@@ -41,6 +41,42 @@ export function SettingsProvider({ children }: PropsWithChildren) {
     };
   }, []);
 
+  useEffect(() => {
+    if (!settings) {
+      return;
+    }
+
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+
+    const root = document.documentElement;
+    const media = window.matchMedia('(prefers-color-scheme: dark)');
+    const theme = settings.theme;
+
+    const resolveTheme = () => (theme === 'system' ? (media.matches ? 'dark' : 'light') : theme);
+
+    const applyTheme = () => {
+      const resolvedTheme = resolveTheme();
+      root.classList.toggle('dark', resolvedTheme === 'dark');
+      root.dataset.theme = resolvedTheme;
+    };
+
+    applyTheme();
+
+    if (theme !== 'system') {
+      return () => {
+        applyTheme();
+      };
+    }
+
+    const handleChange = () => applyTheme();
+    media.addEventListener('change', handleChange);
+    return () => {
+      media.removeEventListener('change', handleChange);
+    };
+  }, [settings?.theme]);
+
   const value = useMemo<SettingsContextValue>(
     () => ({
       settings,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{ts,tsx}'],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- add a persisted theme preference to the settings schema with defaults and validation
- sync the selected theme to the document root and expose radio toggle controls in the Settings page
- enable class-based dark mode handling in Tailwind for manual theme switching

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68db41dbcd948331b0de8839dc0cf94e