### PR TITLE
Fix calendar orientation independence from pay-week preference

### DIFF
--- a/src/app/routes/ShiftsPage.tsx
+++ b/src/app/routes/ShiftsPage.tsx
@@ -22,8 +22,10 @@ import {
 import Modal from '../components/Modal';
 import ShiftForm, { type ShiftFormValues } from '../components/ShiftForm';
 import { createShift, deleteShift, getAllShifts, updateShift } from '../db/repo';
-import type { Shift } from '../db/schema';
+import type { Shift, WeekStart } from '../db/schema';
 import { useSettings } from '../state/SettingsContext';
+
+export const CALENDAR_WEEK_START: WeekStart = 1;
 
 export default function ShiftsPage() {
   const queryClient = useQueryClient();
@@ -38,21 +40,20 @@ export default function ShiftsPage() {
   });
 
   const currency = settings?.currency ?? 'USD';
-  const weekStartsOn = (settings?.weekStartsOn ?? 1) as 0 | 1;
 
   const calendarDays = useMemo(() => {
-    const options = { weekStartsOn } as const;
+    const options = { weekStartsOn: CALENDAR_WEEK_START } as const;
     const start = startOfWeek(startOfMonth(currentMonth), options);
     const end = endOfWeek(endOfMonth(currentMonth), options);
     const total = differenceInCalendarDays(end, start) + 1;
     return Array.from({ length: total }, (_, index) => addDays(start, index));
-  }, [currentMonth, weekStartsOn]);
+  }, [currentMonth]);
 
   const weekdayLabels = useMemo(() => {
-    const options = { weekStartsOn } as const;
+    const options = { weekStartsOn: CALENDAR_WEEK_START } as const;
     const start = startOfWeek(new Date(), options);
     return Array.from({ length: 7 }, (_, index) => format(addDays(start, index), 'EEE'));
-  }, [weekStartsOn]);
+  }, []);
 
   const shiftsByDay = useMemo(() => {
     const grouped = new Map<string, Shift[]>();

--- a/src/app/routes/SummaryPage.tsx
+++ b/src/app/routes/SummaryPage.tsx
@@ -3,11 +3,11 @@ import { useQuery } from '@tanstack/react-query';
 import WeekNavigator from '../components/WeekNavigator';
 import ShiftCard from '../components/ShiftCard';
 import { getShiftsForWeek } from '../db/repo';
-import { useSettings, useWeekStart } from '../state/SettingsContext';
+import { usePayWeekStart, useSettings } from '../state/SettingsContext';
 import { getWeekKey, getWeekRangeForDate, type WeekRange } from '../logic/week';
 
 function useWeekNavigation(): [WeekRange, () => void, () => void] {
-  const weekStartsOn = useWeekStart();
+  const weekStartsOn = usePayWeekStart();
   const [anchorDate, setAnchorDate] = useState(() => new Date());
 
   const range = useMemo(() => getWeekRangeForDate(anchorDate, weekStartsOn), [anchorDate, weekStartsOn]);
@@ -20,7 +20,7 @@ function useWeekNavigation(): [WeekRange, () => void, () => void] {
 
 export default function SummaryPage() {
   const { settings } = useSettings();
-  const weekStartsOn = useWeekStart();
+  const weekStartsOn = usePayWeekStart();
   const [range, goPrev, goNext] = useWeekNavigation();
   const weekKey = useMemo(() => getWeekKey(range.start, weekStartsOn), [range.start, weekStartsOn]);
   const { data: shifts = [], isLoading } = useQuery({

--- a/src/app/state/SettingsContext.tsx
+++ b/src/app/state/SettingsContext.tsx
@@ -102,7 +102,11 @@ export function useSettings() {
   return context;
 }
 
-export function useWeekStart(): WeekStart {
+/**
+ * Returns the week start preference used for pay-period grouping.
+ * The calendar UI keeps a fixed orientation independent from this value.
+ */
+export function usePayWeekStart(): WeekStart {
   const { settings } = useSettings();
   return settings?.weekStartsOn ?? 1;
 }

--- a/src/tests/routes/ShiftsPage.test.ts
+++ b/src/tests/routes/ShiftsPage.test.ts
@@ -1,0 +1,15 @@
+import { addDays, startOfWeek } from 'date-fns';
+import { describe, expect, it } from 'vitest';
+import { CALENDAR_WEEK_START } from '../../app/routes/ShiftsPage';
+
+describe('ShiftsPage calendar orientation', () => {
+  it('pins the calendar grid to start on Monday', () => {
+    expect(CALENDAR_WEEK_START).toBe(1);
+
+    const anchor = new Date(2024, 11, 18, 12, 0, 0);
+    const start = startOfWeek(anchor, { weekStartsOn: CALENDAR_WEEK_START });
+
+    expect(start.getDay()).toBe(1);
+    expect(addDays(start, 6).getDay()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- pin the Shifts page calendar grid to a Monday start via a dedicated constant
- rename the settings helper to clarify it returns the pay-week start used by summaries
- add a regression test covering the fixed calendar orientation

## Testing
- npx vitest run src/tests/routes/ShiftsPage.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68db45fbc9a88331805b8a340195651c