### PR TITLE
Add 24-hour time format preference

### DIFF
--- a/src/app/components/ShiftCard.tsx
+++ b/src/app/components/ShiftCard.tsx
@@ -1,14 +1,10 @@
 import type { Shift } from '../db/schema';
+import { useTimeFormatter } from '../state/useTimeFormatter';
 
 const dateFormatter = new Intl.DateTimeFormat(undefined, {
   weekday: 'short',
   month: 'short',
   day: 'numeric'
-});
-
-const timeFormatter = new Intl.DateTimeFormat(undefined, {
-  hour: '2-digit',
-  minute: '2-digit'
 });
 
 export type ShiftCardProps = {
@@ -19,6 +15,7 @@ export type ShiftCardProps = {
 };
 
 export default function ShiftCard({ shift, currency, onEdit, onDelete }: ShiftCardProps) {
+  const timeFormatter = useTimeFormatter();
   const startDate = new Date(shift.startISO);
   const endDate = shift.endISO ? new Date(shift.endISO) : null;
   const currencyFormatter = new Intl.NumberFormat(undefined, {

--- a/src/app/db/schema.ts
+++ b/src/app/db/schema.ts
@@ -15,6 +15,7 @@ export type Settings = {
   weekStartsOn: WeekStart;
   currency: string;
   theme: ThemePreference;
+  use24HourTime: boolean;
   penaltyDailyWindowEnabled: boolean;
   penaltyDailyStartMinute: number;
   penaltyDailyEndMinute: number;
@@ -49,6 +50,7 @@ export const DEFAULT_SETTINGS: Settings = {
   weekStartsOn: 1,
   currency: 'USD',
   theme: 'system',
+  use24HourTime: false,
   penaltyDailyWindowEnabled: true,
   penaltyDailyStartMinute: 0,
   penaltyDailyEndMinute: 7 * 60,
@@ -144,6 +146,7 @@ export function applySettingsDefaults(partial: Partial<Settings> | undefined): S
     publicHolidayCountry
   );
   const publicHolidayDates = sanitizeHolidayDates(base.publicHolidayDates ?? DEFAULT_SETTINGS.publicHolidayDates);
+  const use24HourTime = Boolean(base.use24HourTime ?? DEFAULT_SETTINGS.use24HourTime);
 
   return {
     id: 'singleton',
@@ -152,6 +155,7 @@ export function applySettingsDefaults(partial: Partial<Settings> | undefined): S
     weekStartsOn: (typeof base.weekStartsOn === 'number' ? base.weekStartsOn : DEFAULT_SETTINGS.weekStartsOn) as WeekStart,
     currency: typeof base.currency === 'string' && base.currency.trim() ? base.currency : DEFAULT_SETTINGS.currency,
     theme: sanitizeTheme(base.theme ?? DEFAULT_SETTINGS.theme),
+    use24HourTime,
     penaltyDailyWindowEnabled,
     penaltyDailyStartMinute: startMinute,
     penaltyDailyEndMinute: endMinute,

--- a/src/app/routes/SettingsPage.tsx
+++ b/src/app/routes/SettingsPage.tsx
@@ -66,6 +66,7 @@ export default function SettingsPage() {
   const [weekStartsOn, setWeekStartsOn] = useState<WeekStart>(() => settings?.weekStartsOn ?? 1);
   const [currency, setCurrency] = useState(() => settings?.currency ?? 'USD');
   const [theme, setTheme] = useState<ThemePreference>(() => settings?.theme ?? 'system');
+  const [use24HourTime, setUse24HourTime] = useState(() => settings?.use24HourTime ?? false);
   const [penaltyStartTime, setPenaltyStartTime] = useState(() => minutesToTime(settings?.penaltyDailyStartMinute ?? 0));
   const [penaltyEndTime, setPenaltyEndTime] = useState(() => minutesToTime(settings?.penaltyDailyEndMinute ?? 7 * 60));
   const [penaltyDailyWindowEnabled, setPenaltyDailyWindowEnabled] = useState(
@@ -91,6 +92,7 @@ export default function SettingsPage() {
       setWeekStartsOn(settings.weekStartsOn);
       setCurrency(settings.currency);
       setTheme(settings.theme ?? 'system');
+      setUse24HourTime(settings.use24HourTime ?? false);
       setPenaltyDailyWindowEnabled(settings.penaltyDailyWindowEnabled);
       setPenaltyStartTime(minutesToTime(settings.penaltyDailyStartMinute));
       setPenaltyEndTime(minutesToTime(settings.penaltyDailyEndMinute));
@@ -237,6 +239,7 @@ export default function SettingsPage() {
               weekStartsOn,
               currency,
               theme,
+              use24HourTime,
               penaltyDailyWindowEnabled,
               penaltyDailyStartMinute: startMinutes,
               penaltyDailyEndMinute: endMinutes,
@@ -314,6 +317,21 @@ export default function SettingsPage() {
             className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm uppercase shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40 dark:border-slate-700 dark:bg-slate-900"
             maxLength={3}
           />
+        </div>
+        <div className="grid gap-2">
+          <span className="text-xs font-semibold uppercase text-slate-500">Time format</span>
+          <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-200">
+            <input
+              type="checkbox"
+              checked={use24HourTime}
+              onChange={(event) => setUse24HourTime(event.target.checked)}
+              className="h-4 w-4 rounded border-slate-300 text-primary focus:ring-primary"
+            />
+            Use 24-hour clock
+          </label>
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            Applies to shift start and end times shown in the app.
+          </p>
         </div>
         <fieldset className="grid gap-3">
           <legend className="text-xs font-semibold uppercase text-slate-500">Appearance</legend>

--- a/src/app/routes/ShiftsPage.tsx
+++ b/src/app/routes/ShiftsPage.tsx
@@ -24,6 +24,7 @@ import ShiftForm, { type ShiftFormValues } from '../components/ShiftForm';
 import { createShift, deleteShift, getAllShifts, updateShift } from '../db/repo';
 import type { Shift, WeekStart } from '../db/schema';
 import { useSettings } from '../state/SettingsContext';
+import { useTimeFormatter } from '../state/useTimeFormatter';
 
 export const CALENDAR_WEEK_START: WeekStart = 1;
 
@@ -38,6 +39,8 @@ export default function ShiftsPage() {
     queryFn: getAllShifts,
     enabled: Boolean(settings)
   });
+
+  const timeFormatter = useTimeFormatter();
 
   const calendarDays = useMemo(() => {
     const options = { weekStartsOn: CALENDAR_WEEK_START } as const;
@@ -69,15 +72,6 @@ export default function ShiftsPage() {
 
     return grouped;
   }, [shifts]);
-
-  const timeFormatter = useMemo(
-    () =>
-      new Intl.DateTimeFormat(undefined, {
-        hour: '2-digit',
-        minute: '2-digit'
-      }),
-    []
-  );
 
   const createMutation = useMutation({
     mutationFn: async (values: ShiftFormValues) => {

--- a/src/app/state/useTimeFormatter.ts
+++ b/src/app/state/useTimeFormatter.ts
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+import { useSettings } from './SettingsContext';
+
+export function useTimeFormatter() {
+  const { settings } = useSettings();
+  return useMemo(
+    () =>
+      new Intl.DateTimeFormat(undefined, {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: settings?.use24HourTime ? false : undefined,
+        hourCycle: settings?.use24HourTime ? 'h23' : undefined
+      }),
+    [settings?.use24HourTime]
+  );
+}


### PR DESCRIPTION
## Summary
- add a persisted 24-hour time preference to the settings model and defaults
- surface a toggle on the settings page to control the preference
- reuse the preference when formatting shift times across the UI via a shared hook

## Testing
- npm run test *(fails: Playwright smoke spec expects Playwright test runner instead of Vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68db4ad15e34833193bc338f66fbb164