### PR TITLE
Include scripts directory during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 
 # Install deps first (better layer caching)
 COPY package*.json ./
+COPY scripts ./scripts
 RUN npm ci
 
 # Copy source


### PR DESCRIPTION
## Summary
- copy the scripts directory into the Docker build stage before running npm ci so install-playwright is available

## Testing
- docker build -t shift-recorder-test . *(fails: docker not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db5a6ff388833184501b93b97d9533