### PR TITLE
Fix SettingsPage test typings for production build

### DIFF
--- a/src/tests/routes/SettingsPage.test.tsx
+++ b/src/tests/routes/SettingsPage.test.tsx
@@ -5,12 +5,12 @@ import { DEFAULT_SETTINGS, type Settings } from '../../app/db/schema';
 import type { HolidayRegion } from '../../app/logic/publicHolidays';
 
 const useSettingsMock = vi.fn();
-const mockFetchPublicHolidayRegions = vi.fn(
-  async (_country: string): Promise<HolidayRegion[]> => []
-);
-const mockFetchPublicHolidays = vi.fn(
-  async (): Promise<string[]> => []
-);
+const mockFetchPublicHolidayRegions = vi.fn<
+  (country: string) => Promise<HolidayRegion[]>
+>(async (_country) => []);
+const mockFetchPublicHolidays = vi.fn<
+  (country: string, years: number[], subdivision?: string) => Promise<string[]>
+>(async (_country, _years, _subdivision) => []);
 
 vi.mock('../../app/state/SettingsContext', () => ({
   useSettings: () => useSettingsMock()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["vite/client", "happy-dom"],
+    "types": ["vite/client", "happy-dom", "@testing-library/jest-dom"],
     "strict": true,
     "skipLibCheck": true
   },


### PR DESCRIPTION
## Summary
- add jest-dom typings to the TypeScript configuration so Vitest matchers are recognised
- type the SettingsPage public holiday mocks to match their call signatures

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db6187c01c83319fd1e9d5bba26f0d