### PR TITLE
Ensure modal content scrolls on short viewports

### DIFF
--- a/src/app/components/Modal.tsx
+++ b/src/app/components/Modal.tsx
@@ -40,7 +40,8 @@ export default function Modal({ isOpen, title, onClose, children }: ModalProps) 
         role="dialog"
         aria-modal="true"
         aria-labelledby={titleId}
-        className="relative z-10 w-full max-w-xl rounded-3xl border border-slate-200 bg-white p-6 shadow-xl dark:border-slate-800 dark:bg-slate-950"
+        tabIndex={-1}
+        className="relative z-10 w-full max-w-xl max-h-[calc(100vh-4rem)] overflow-y-auto rounded-3xl border border-slate-200 bg-white p-6 shadow-xl dark:border-slate-800 dark:bg-slate-950"
       >
         <div className="flex items-start justify-between gap-4">
           <h2 id={titleId} className="text-lg font-semibold text-slate-900 dark:text-slate-50">


### PR DESCRIPTION
## Summary
- add a max height and overflow behavior to the modal dialog container so tall content can scroll
- make the dialog focusable to keep focus within the scrollable region

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcbc543d64833189997bea6dce298a