### PR TITLE
Adjust shifts calendar overflow behavior

### DIFF
--- a/src/app/routes/ShiftsPage.tsx
+++ b/src/app/routes/ShiftsPage.tsx
@@ -278,7 +278,7 @@ export default function ShiftsPage() {
                   </span>
                 ))}
               </div>
-              <div className="mt-1 grid flex-1 min-h-0 grid-cols-7 gap-2 overflow-y-auto pb-2 sm:mt-2">
+              <div className="mt-1 grid flex-1 min-h-0 grid-cols-7 gap-2 overflow-visible pb-2 sm:mt-2 sm:overflow-y-auto">
                 {calendarDays.map((day) => {
                   const dateKey = format(day, 'yyyy-MM-dd');
                   const dayShifts = shiftsByDay.get(dateKey) ?? [];


### PR DESCRIPTION
## Summary
- ensure the calendar grid uses overflow scrolling only on small-and-up breakpoints so mobile layouts scroll the whole page

## Testing
- ✅ Viewed Shifts page at 375px viewport (Playwright)


------
https://chatgpt.com/codex/tasks/task_e_68dcbc55d26883318bb552c46939668e