### PR TITLE
Improve service worker auto update handling

### DIFF
--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -1,14 +1,23 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { registerSW } from 'virtual:pwa-register';
 import App from './App';
 import './styles/index.css';
 import { SettingsProvider } from './state/SettingsContext';
-import { registerSW } from 'virtual:pwa-register';
 
 const queryClient = new QueryClient();
 
-registerSW({ immediate: true });
+if (import.meta.env.PROD) {
+  const updateSW = registerSW({
+    immediate: true,
+    onNeedRefresh() {
+      updateSW(true).then(() => {
+        window.location.reload();
+      });
+    },
+  }) as (reloadPage?: boolean) => Promise<void>;
+}
 
 const container = document.getElementById('root');
 if (!container) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,10 @@ export default defineConfig({
     VitePWA({
       registerType: 'autoUpdate',
       includeAssets: ['favicon.svg', 'robots.txt', 'apple-touch-icon.svg'],
+      workbox: {
+        clientsClaim: true,
+        skipWaiting: true,
+      },
       manifest: {
         name: 'Shift Recorder',
         short_name: 'Shift Recorder',


### PR DESCRIPTION
## Summary
- register the PWA service worker only in production and trigger a reload after updating
- enable immediate activation of new service workers with clientsClaim and skipWaiting in Vite PWA config

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcbc7bbc248331986951ea5e8e34a7