### PR TITLE
Adjust mobile calendar halo to track selected day

### DIFF
--- a/src/app/routes/ShiftsPage.tsx
+++ b/src/app/routes/ShiftsPage.tsx
@@ -298,8 +298,11 @@ export default function ShiftsPage() {
                       : inCurrentMonth
                         ? 'text-slate-700 dark:text-slate-100'
                         : 'text-slate-400 dark:text-slate-600',
+                    isSelected
+                      ? 'ring-2 ring-emerald-300 ring-offset-2 ring-offset-white dark:ring-emerald-400/70 dark:ring-offset-slate-950 sm:ring-0 sm:ring-offset-0'
+                      : null,
                     hasUpcomingShift && !isSelected && !isCurrentDay
-                      ? 'bg-emerald-100 text-emerald-800 ring-2 ring-emerald-300 ring-offset-2 dark:bg-emerald-500/20 dark:text-emerald-100 dark:ring-emerald-400/70 dark:ring-offset-slate-900'
+                      ? 'sm:bg-emerald-100 sm:text-emerald-800 sm:ring-2 sm:ring-emerald-300 sm:ring-offset-2 sm:ring-offset-white sm:dark:bg-emerald-500/20 sm:dark:text-emerald-100 sm:dark:ring-emerald-400/70 sm:dark:ring-offset-slate-900'
                       : null
                   ]
                     .filter(Boolean)


### PR DESCRIPTION
## Summary
- add a mobile-only ring style so the selected calendar date stays highlighted
- preserve the existing upcoming-shift halo on larger screens by scoping those classes to `sm` and up

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcc15c2d988331acb2d3537d8fa049