### PR TITLE
Handle duplicate and overlapping shifts during CSV import

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
 import { BrowserRouter, NavLink, Route, Routes } from 'react-router-dom';
 import { getSettings } from './db/repo';
 import SummaryPage from './routes/SummaryPage';
@@ -6,6 +7,7 @@ import ShiftsPage from './routes/ShiftsPage';
 import SettingsPage from './routes/SettingsPage';
 import { useSettings } from './state/SettingsContext';
 import NotificationManager from './state/NotificationManager';
+import ImportExportModal from './components/ImportExportModal';
 
 function NavigationLink({ to, label }: { to: string; label: string }) {
   return (
@@ -26,6 +28,7 @@ function NavigationLink({ to, label }: { to: string; label: string }) {
 
 function Layout() {
   const { settings } = useSettings();
+  const [isImportExportOpen, setIsImportExportOpen] = useState(false);
   useQuery({
     queryKey: ['settings'],
     queryFn: getSettings,
@@ -45,6 +48,13 @@ function Layout() {
             <NavigationLink to="/" label="Summary" />
             <NavigationLink to="/shifts" label="Shifts" />
             <NavigationLink to="/settings" label="Settings" />
+            <button
+              type="button"
+              onClick={() => setIsImportExportOpen(true)}
+              className="px-4 py-2 text-sm font-medium text-slate-500 transition-colors hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100"
+            >
+              Import/Export
+            </button>
           </nav>
         </div>
       </header>
@@ -55,6 +65,7 @@ function Layout() {
           <Route path="/settings" element={<SettingsPage />} />
         </Routes>
       </main>
+      <ImportExportModal isOpen={isImportExportOpen} onClose={() => setIsImportExportOpen(false)} />
     </div>
   );
 }

--- a/src/app/components/ImportExportModal.tsx
+++ b/src/app/components/ImportExportModal.tsx
@@ -1,0 +1,436 @@
+import { ArrowDownTrayIcon, ArrowUpTrayIcon } from '@heroicons/react/24/outline';
+import { format } from 'date-fns';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent
+} from 'react';
+import { getAllShifts, importShifts, type ShiftImportResult } from '../db/repo';
+import {
+  getShiftImportTemplateCsv,
+  parseShiftsCsv,
+  shiftsToCsv,
+  type ShiftCsvParseError,
+  type ShiftCsvImportRow
+} from '../logic/csv';
+import Modal from './Modal';
+import { useSettings } from '../state/SettingsContext';
+
+const EXPORT_FILENAME = 'shift-export';
+const IMPORT_LOG_FILENAME = 'shift-import-log.csv';
+
+type ImportRowStatus = ShiftCsvImportRow & {
+  status: 'success' | 'duplicate' | 'overlap' | 'failed';
+  message?: string;
+};
+
+type ImportReviewState = {
+  rows: ImportRowStatus[];
+  summary: {
+    total: number;
+    success: number;
+    duplicate: number;
+    overlap: number;
+    failed: number;
+  };
+  logUrl: string;
+};
+
+type ImportExportModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+const STATUS_COPY: Record<ImportRowStatus['status'], { label: string; className: string }> = {
+  success: {
+    label: 'Imported',
+    className: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200'
+  },
+  duplicate: {
+    label: 'Duplicate',
+    className: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200'
+  },
+  overlap: {
+    label: 'Overlapping',
+    className: 'bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-200'
+  },
+  failed: {
+    label: 'Failed',
+    className: 'bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-200'
+  }
+};
+
+function escapeCsv(value: string): string {
+  if (value.includes('"') || value.includes(',') || value.includes('\n') || value.includes('\r')) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function buildLogContent(rows: ImportRowStatus[], dataErrors: ShiftCsvParseError[]): string {
+  const header = 'line,date,start,finish,note,status,message';
+  const dataLines = rows.map((row) => {
+    const message = row.message ?? '';
+    return [
+      row.line.toString(),
+      escapeCsv(row.date),
+      escapeCsv(row.start),
+      escapeCsv(row.finish),
+      escapeCsv(row.note),
+      escapeCsv(STATUS_COPY[row.status].label),
+      escapeCsv(message)
+    ].join(',');
+  });
+
+  const errorLines = dataErrors
+    .filter((error) => !rows.some((row) => row.line === error.line))
+    .map((error) => [error.line.toString(), '', '', '', '', 'Failed', escapeCsv(error.message)].join(','));
+
+  return [header, ...dataLines, ...errorLines].join('\n');
+}
+
+export default function ImportExportModal({ isOpen, onClose }: ImportExportModalProps) {
+  const { settings } = useSettings();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [infoMessage, setInfoMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [review, setReview] = useState<ImportReviewState | null>(null);
+  const [dataErrors, setDataErrors] = useState<ShiftCsvParseError[]>([]);
+
+  const templateHref = useMemo(() => {
+    const blob = new Blob([getShiftImportTemplateCsv()], { type: 'text/csv;charset=utf-8' });
+    return URL.createObjectURL(blob);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      URL.revokeObjectURL(templateHref);
+    };
+  }, [templateHref]);
+
+  const resetReview = useCallback(() => {
+    setReview((previous) => {
+      if (previous?.logUrl) {
+        URL.revokeObjectURL(previous.logUrl);
+      }
+      return null;
+    });
+    setDataErrors([]);
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setInfoMessage(null);
+      setErrorMessage(null);
+      resetReview();
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
+    }
+  }, [isOpen, resetReview]);
+
+  useEffect(() => {
+    return () => {
+      if (review?.logUrl) {
+        URL.revokeObjectURL(review.logUrl);
+      }
+    };
+  }, [review]);
+
+  const handleExport = async () => {
+    setIsProcessing(true);
+    setErrorMessage(null);
+    setInfoMessage(null);
+
+    try {
+      const shifts = await getAllShifts();
+      if (shifts.length === 0) {
+        setInfoMessage('No shifts available to export.');
+        return;
+      }
+
+      const csvContent = shiftsToCsv(shifts);
+      const timestamp = format(new Date(), 'yyyyMMdd-HHmmss');
+      const fileName = `${EXPORT_FILENAME}-${timestamp}.csv`;
+      const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = fileName;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+      setInfoMessage(`Exported ${shifts.length} shift${shifts.length === 1 ? '' : 's'} to ${fileName}.`);
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : 'Failed to export shifts.');
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const triggerFilePicker = () => {
+    if (isProcessing) return;
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file || !settings) return;
+
+    setIsProcessing(true);
+    setErrorMessage(null);
+    setInfoMessage(null);
+
+    try {
+      const text = await file.text();
+      const { entries, errors, rows } = parseShiftsCsv(text);
+      const headerErrors = errors.filter((error) => error.line === 1);
+
+      if (entries.length === 0 && rows.length === 0 && headerErrors.length > 0) {
+        setErrorMessage(headerErrors[0].message);
+        resetReview();
+        return;
+      }
+
+      const importResults: ShiftImportResult[] = await importShifts(entries, settings);
+
+      const resultMap = new Map(importResults.map((result) => [result.line, result]));
+      const errorMap = new Map(errors.filter((error) => error.line !== 1).map((error) => [error.line, error.message]));
+
+      const rowStatuses: ImportRowStatus[] = rows.map((row) => {
+        const parseErrorMessage = errorMap.get(row.line);
+        if (parseErrorMessage) {
+          return { ...row, status: 'failed', message: parseErrorMessage };
+        }
+
+        const importResult = resultMap.get(row.line);
+        if (importResult) {
+          return {
+            ...row,
+            status: importResult.status,
+            message:
+              importResult.status === 'success'
+                ? 'Imported successfully'
+                : importResult.message ?? undefined
+          };
+        }
+
+        return {
+          ...row,
+          status: 'failed',
+          message: 'Row skipped due to an unknown issue'
+        };
+      });
+
+      const summary = rowStatuses.reduce(
+        (accumulator, row) => {
+          accumulator.total += 1;
+          accumulator[row.status] += 1;
+          return accumulator;
+        },
+        { total: 0, success: 0, duplicate: 0, overlap: 0, failed: 0 }
+      );
+
+      const logContent = buildLogContent(rowStatuses, errors);
+      const logBlob = new Blob([logContent], { type: 'text/csv;charset=utf-8' });
+      const logUrl = URL.createObjectURL(logBlob);
+
+      setDataErrors(errors.filter((error) => error.line !== 1));
+      setReview((previous) => {
+        if (previous?.logUrl) {
+          URL.revokeObjectURL(previous.logUrl);
+        }
+        return {
+          rows: rowStatuses,
+          summary,
+          logUrl
+        };
+      });
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : 'Failed to import shifts.');
+      resetReview();
+    } finally {
+      setIsProcessing(false);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Import & Export Shifts">
+      <div className="flex flex-col gap-6">
+        {review ? (
+          <div className="space-y-5">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <h3 className="text-base font-semibold">Import results</h3>
+                <p className="text-sm text-slate-500 dark:text-slate-400">
+                  Imported {review.summary.success} of {review.summary.total} row{review.summary.total === 1 ? '' : 's'}.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={triggerFilePicker}
+                  className="inline-flex items-center justify-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:text-slate-900 dark:border-slate-700 dark:text-slate-200 dark:hover:border-slate-500"
+                  disabled={isProcessing || !settings}
+                >
+                  <ArrowUpTrayIcon className="h-4 w-4" aria-hidden="true" />
+                  Import another CSV
+                </button>
+                <a
+                  href={review.logUrl}
+                  download={IMPORT_LOG_FILENAME}
+                  className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow transition hover:bg-primary/90"
+                >
+                  <ArrowDownTrayIcon className="h-4 w-4" aria-hidden="true" />
+                  Download log
+                </a>
+              </div>
+            </div>
+
+            <div className="grid gap-3 rounded-2xl bg-slate-50 p-4 dark:bg-slate-900/40 sm:grid-cols-4">
+              <div className="flex flex-col">
+                <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Imported</span>
+                <span className="text-lg font-semibold">{review.summary.success}</span>
+              </div>
+              <div className="flex flex-col">
+                <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Duplicates</span>
+                <span className="text-lg font-semibold">{review.summary.duplicate}</span>
+              </div>
+              <div className="flex flex-col">
+                <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Overlapping</span>
+                <span className="text-lg font-semibold">{review.summary.overlap}</span>
+              </div>
+              <div className="flex flex-col">
+                <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Failed</span>
+                <span className="text-lg font-semibold">{review.summary.failed}</span>
+              </div>
+            </div>
+
+            <div className="max-h-72 overflow-auto rounded-2xl border border-slate-200 dark:border-slate-800">
+              <table className="min-w-full divide-y divide-slate-200 text-left text-sm dark:divide-slate-800">
+                <thead className="bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:bg-slate-900/40 dark:text-slate-400">
+                  <tr>
+                    <th className="px-4 py-3">Line</th>
+                    <th className="px-4 py-3">Date</th>
+                    <th className="px-4 py-3">Start</th>
+                    <th className="px-4 py-3">Finish</th>
+                    <th className="px-4 py-3">Notes</th>
+                    <th className="px-4 py-3">Status</th>
+                    <th className="px-4 py-3">Details</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-200 dark:divide-slate-800">
+                  {review.rows.map((row) => {
+                    const status = STATUS_COPY[row.status];
+                    return (
+                      <tr key={row.line} className="align-top">
+                        <td className="px-4 py-3 font-mono text-xs text-slate-500 dark:text-slate-400">{row.line}</td>
+                        <td className="px-4 py-3">{row.date}</td>
+                        <td className="px-4 py-3">{row.start}</td>
+                        <td className="px-4 py-3">{row.finish}</td>
+                        <td className="px-4 py-3 text-slate-600 dark:text-slate-300">{row.note || '—'}</td>
+                        <td className="px-4 py-3">
+                          <span className={`inline-flex rounded-full px-2 py-1 text-xs font-semibold ${status.className}`}>
+                            {status.label}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 text-slate-600 dark:text-slate-300">
+                          {row.message ?? '—'}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+
+            {dataErrors.length > 0 && (
+              <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-600/60 dark:bg-amber-900/30 dark:text-amber-100">
+                <p className="font-semibold">Rows with issues</p>
+                <ul className="mt-2 space-y-1">
+                  {dataErrors.map((error) => (
+                    <li key={`${error.line}-${error.message}`}>
+                      Line {error.line}: {error.message}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        ) : (
+          <>
+            <div className="grid gap-3">
+              <button
+                type="button"
+                onClick={handleExport}
+                className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={isProcessing}
+              >
+                <ArrowDownTrayIcon className="h-4 w-4" aria-hidden="true" />
+                Download all shifts (CSV)
+              </button>
+              <button
+                type="button"
+                onClick={triggerFilePicker}
+                className="inline-flex items-center justify-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:text-slate-900 dark:border-slate-700 dark:text-slate-200 dark:hover:border-slate-500"
+                disabled={isProcessing || !settings}
+                title={!settings ? 'Settings are still loading' : undefined}
+              >
+                <ArrowUpTrayIcon className="h-4 w-4" aria-hidden="true" />
+                Import shifts from CSV
+              </button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".csv,text/csv"
+                className="hidden"
+                onChange={handleFileChange}
+              />
+            </div>
+
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600 dark:border-slate-800 dark:bg-slate-900/50 dark:text-slate-300">
+              <h3 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-100">CSV format</h3>
+              <ul className="list-disc space-y-1 pl-5">
+                <li>Use header columns: <code>date,start,finish,notes</code>.</li>
+                <li>Date must be in <code>YYYY-MM-DD</code> format.</li>
+                <li>Times use 24-hour <code>HH:mm</code>; overnight shifts roll to the next day automatically.</li>
+                <li>Notes are optional and can be left blank.</li>
+                <li>Duplicate or overlapping rows will be skipped and logged.</li>
+              </ul>
+              <a
+                href={templateHref}
+                download="shift-import-template.csv"
+                className="mt-3 inline-flex items-center gap-1 text-sm font-semibold text-primary hover:underline"
+              >
+                Download template CSV
+              </a>
+            </div>
+
+            {(infoMessage || errorMessage) && (
+              <div className="space-y-3">
+                {infoMessage && (
+                  <p className="rounded-xl bg-emerald-50 px-4 py-2 text-sm font-medium text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-200">
+                    {infoMessage}
+                  </p>
+                )}
+                {errorMessage && (
+                  <p className="rounded-xl bg-rose-50 px-4 py-2 text-sm font-medium text-rose-700 dark:bg-rose-900/40 dark:text-rose-200">
+                    {errorMessage}
+                  </p>
+                )}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/src/app/logic/csv.ts
+++ b/src/app/logic/csv.ts
@@ -1,0 +1,220 @@
+import { addDays, format, formatISO, isValid, parse } from 'date-fns';
+import type { Shift } from '../db/schema';
+
+export type ShiftCsvParseError = {
+  line: number;
+  message: string;
+};
+
+export type ShiftCsvImportEntry = {
+  line: number;
+  startISO: string;
+  endISO: string;
+  note?: string;
+};
+
+export type ShiftCsvImportRow = {
+  line: number;
+  date: string;
+  start: string;
+  finish: string;
+  note: string;
+};
+
+const HEADER = ['date', 'start', 'finish', 'notes'] as const;
+
+function escapeCsvValue(value: string): string {
+  if (value.includes('"') || value.includes(',') || value.includes('\n') || value.includes('\r')) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function normalizeHeader(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function parseCsv(content: string): string[][] {
+  const rows: string[][] = [];
+  let currentRow: string[] = [];
+  let currentValue = '';
+  let inQuotes = false;
+
+  for (let index = 0; index < content.length; index += 1) {
+    const char = content[index];
+
+    if (char === '"') {
+      if (inQuotes && content[index + 1] === '"') {
+        currentValue += '"';
+        index += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+
+    if (!inQuotes && (char === '\n' || char === '\r')) {
+      currentRow.push(currentValue);
+      currentValue = '';
+      if (char === '\r' && content[index + 1] === '\n') {
+        index += 1;
+      }
+      rows.push(currentRow);
+      currentRow = [];
+      continue;
+    }
+
+    if (!inQuotes && char === ',') {
+      currentRow.push(currentValue);
+      currentValue = '';
+      continue;
+    }
+
+    currentValue += char;
+  }
+
+  currentRow.push(currentValue);
+  rows.push(currentRow);
+
+  return rows;
+}
+
+function parseTime(value: string): { hours: number; minutes: number } | null {
+  const trimmed = value.trim();
+  const match = /^([01]?\d|2[0-3]):([0-5]\d)$/.exec(trimmed);
+  if (!match) return null;
+  return { hours: Number(match[1]), minutes: Number(match[2]) };
+}
+
+export function shiftsToCsv(shifts: Shift[]): string {
+  const lines = [HEADER.join(',')];
+
+  shifts.forEach((shift) => {
+    const startDate = new Date(shift.startISO);
+    const endDate = shift.endISO ? new Date(shift.endISO) : null;
+    const cells = [
+      format(startDate, 'yyyy-MM-dd'),
+      format(startDate, 'HH:mm'),
+      endDate ? format(endDate, 'HH:mm') : '',
+      shift.note?.trim() ?? ''
+    ];
+    lines.push(cells.map(escapeCsvValue).join(','));
+  });
+
+  return lines.join('\n');
+}
+
+function trimBom(content: string): string {
+  if (content.length > 0 && content.charCodeAt(0) === 0xfeff) {
+    return content.slice(1);
+  }
+  return content;
+}
+
+export function parseShiftsCsv(content: string): {
+  entries: ShiftCsvImportEntry[];
+  errors: ShiftCsvParseError[];
+  rows: ShiftCsvImportRow[];
+} {
+  const normalized = trimBom(content);
+  const rows = parseCsv(normalized).filter((row) => row.some((cell) => cell.trim() !== ''));
+
+  if (rows.length === 0) {
+    return {
+      entries: [],
+      errors: [
+        {
+          line: 1,
+          message: 'CSV file is empty'
+        }
+      ],
+      rows: []
+    };
+  }
+
+  const header = rows[0].map(normalizeHeader);
+  if (HEADER.some((expected, index) => header[index] !== expected)) {
+    return {
+      entries: [],
+      errors: [
+        {
+          line: 1,
+          message: `Invalid header row. Expected: ${HEADER.join(', ')}`
+        }
+      ],
+      rows: []
+    };
+  }
+
+  const entries: ShiftCsvImportEntry[] = [];
+  const errors: ShiftCsvParseError[] = [];
+  const displayRows: ShiftCsvImportRow[] = [];
+
+  for (let rowIndex = 1; rowIndex < rows.length; rowIndex += 1) {
+    const row = rows[rowIndex];
+    if (!row || row.length === 0) {
+      continue;
+    }
+
+    const [dateRaw = '', startRaw = '', finishRaw = '', noteRaw = ''] = row;
+    const lineNumber = rowIndex + 1;
+    const dateValue = dateRaw.trim();
+    const startValue = startRaw.trim();
+    const finishValue = finishRaw.trim();
+    const note = noteRaw.trim();
+
+    if (!dateValue && !startValue && !finishValue && !note) {
+      continue;
+    }
+
+    displayRows.push({
+      line: lineNumber,
+      date: dateValue,
+      start: startValue,
+      finish: finishValue,
+      note
+    });
+
+    const parsedDate = parse(dateValue, 'yyyy-MM-dd', new Date());
+    if (!isValid(parsedDate)) {
+      errors.push({ line: lineNumber, message: 'Date must use format YYYY-MM-DD' });
+      continue;
+    }
+
+    const startTime = parseTime(startValue);
+    if (!startTime) {
+      errors.push({ line: lineNumber, message: 'Start time must use 24-hour HH:mm format' });
+      continue;
+    }
+
+    const finishTime = parseTime(finishValue);
+    if (!finishTime) {
+      errors.push({ line: lineNumber, message: 'Finish time must use 24-hour HH:mm format' });
+      continue;
+    }
+
+    const startDate = new Date(parsedDate);
+    startDate.setHours(startTime.hours, startTime.minutes, 0, 0);
+
+    let endDate = new Date(parsedDate);
+    endDate.setHours(finishTime.hours, finishTime.minutes, 0, 0);
+
+    if (endDate <= startDate) {
+      endDate = addDays(endDate, 1);
+    }
+
+    entries.push({
+      line: lineNumber,
+      startISO: formatISO(startDate),
+      endISO: formatISO(endDate),
+      note: note || undefined
+    });
+  }
+
+  return { entries, errors, rows: displayRows };
+}
+
+export function getShiftImportTemplateCsv(): string {
+  const exampleRow = ['2024-01-01', '09:00', '17:00', 'New Year shift'];
+  return [HEADER.join(','), exampleRow.join(',')].join('\n');
+}

--- a/src/app/logic/importConflicts.ts
+++ b/src/app/logic/importConflicts.ts
@@ -1,0 +1,36 @@
+import type { Shift } from '../db/schema';
+
+type ShiftLike = Pick<Shift, 'startISO' | 'endISO'>;
+
+export type ShiftConflictResult =
+  | { type: 'duplicate'; conflicting: ShiftLike }
+  | { type: 'overlap'; conflicting: ShiftLike }
+  | { type: null };
+
+function toRange(shift: ShiftLike): { start: number; end: number; shift: ShiftLike } {
+  const start = new Date(shift.startISO).getTime();
+  const end = shift.endISO ? new Date(shift.endISO).getTime() : Number.POSITIVE_INFINITY;
+  return { start, end, shift };
+}
+
+function rangesOverlap(a: { start: number; end: number }, b: { start: number; end: number }): boolean {
+  return a.start < b.end && a.end > b.start;
+}
+
+export function findShiftConflict(candidate: ShiftLike, others: ShiftLike[]): ShiftConflictResult {
+  const candidateRange = toRange(candidate);
+
+  for (const other of others) {
+    const otherRange = toRange(other);
+
+    if (candidateRange.start === otherRange.start && candidateRange.end === otherRange.end) {
+      return { type: 'duplicate', conflicting: other };
+    }
+
+    if (rangesOverlap(candidateRange, otherRange)) {
+      return { type: 'overlap', conflicting: other };
+    }
+  }
+
+  return { type: null };
+}

--- a/src/tests/logic/csv.test.ts
+++ b/src/tests/logic/csv.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import type { Shift } from '../../app/db/schema';
+import {
+  getShiftImportTemplateCsv,
+  parseShiftsCsv,
+  shiftsToCsv
+} from '../../app/logic/csv';
+
+function createShift(overrides: Partial<Shift> = {}): Shift {
+  const base: Shift = {
+    id: '1',
+    startISO: '2024-01-01T09:00:00.000Z',
+    endISO: '2024-01-01T17:00:00.000Z',
+    baseMinutes: 480,
+    penaltyMinutes: 0,
+    basePay: 100,
+    penaltyPay: 0,
+    totalPay: 100,
+    weekKey: '2024-01-01',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    note: 'Regular shift'
+  };
+  return { ...base, ...overrides };
+}
+
+describe('shiftsToCsv', () => {
+  it('serializes shifts with escaped values', () => {
+    const shifts: Shift[] = [
+      createShift({
+        note: 'Includes, comma',
+        startISO: '2024-01-02T07:15:00.000Z',
+        endISO: '2024-01-02T15:45:00.000Z'
+      })
+    ];
+
+    const csv = shiftsToCsv(shifts);
+
+    expect(csv).toBe('date,start,finish,notes\n2024-01-02,07:15,15:45,"Includes, comma"');
+  });
+});
+
+describe('parseShiftsCsv', () => {
+  it('parses valid rows and handles overnight spans', () => {
+    const content = `date,start,finish,notes\n2024-01-01,09:00,17:00,Morning\n2024-01-01,22:00,06:00,Overnight`;
+
+    const result = parseShiftsCsv(content);
+
+    expect(result.errors).toEqual([]);
+    expect(result.entries).toHaveLength(2);
+    expect(result.entries[0]).toEqual({
+      line: 2,
+      startISO: '2024-01-01T09:00:00Z',
+      endISO: '2024-01-01T17:00:00Z',
+      note: 'Morning'
+    });
+    expect(result.entries[1]).toEqual({
+      line: 3,
+      startISO: '2024-01-01T22:00:00Z',
+      endISO: '2024-01-02T06:00:00Z',
+      note: 'Overnight'
+    });
+    expect(result.rows).toEqual([
+      { line: 2, date: '2024-01-01', start: '09:00', finish: '17:00', note: 'Morning' },
+      { line: 3, date: '2024-01-01', start: '22:00', finish: '06:00', note: 'Overnight' }
+    ]);
+  });
+
+  it('collects errors for invalid rows without aborting others', () => {
+    const content = `date,start,finish,notes\ninvalid,09:00,17:00,n/a\n2024-01-03,25:00,18:00,wrong start\n2024-01-03,09:00,17:00,Valid row`;
+
+    const result = parseShiftsCsv(content);
+
+    expect(result.entries).toEqual([
+      {
+        line: 4,
+        startISO: '2024-01-03T09:00:00Z',
+        endISO: '2024-01-03T17:00:00Z',
+        note: 'Valid row'
+      }
+    ]);
+    expect(result.errors).toEqual([
+      { line: 2, message: 'Date must use format YYYY-MM-DD' },
+      { line: 3, message: 'Start time must use 24-hour HH:mm format' }
+    ]);
+    expect(result.rows).toEqual([
+      { line: 2, date: 'invalid', start: '09:00', finish: '17:00', note: 'n/a' },
+      { line: 3, date: '2024-01-03', start: '25:00', finish: '18:00', note: 'wrong start' },
+      { line: 4, date: '2024-01-03', start: '09:00', finish: '17:00', note: 'Valid row' }
+    ]);
+  });
+
+  it('requires the expected header row', () => {
+    const result = parseShiftsCsv('foo,bar,baz,qux');
+
+    expect(result.entries).toEqual([]);
+    expect(result.errors).toEqual([
+      { line: 1, message: 'Invalid header row. Expected: date, start, finish, notes' }
+    ]);
+    expect(result.rows).toEqual([]);
+  });
+});
+
+describe('getShiftImportTemplateCsv', () => {
+  it('returns a csv string with header and example row', () => {
+    const template = getShiftImportTemplateCsv();
+    expect(template.split('\n')[0]).toBe('date,start,finish,notes');
+  });
+});

--- a/src/tests/logic/importConflicts.test.ts
+++ b/src/tests/logic/importConflicts.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { findShiftConflict } from '../../app/logic/importConflicts';
+
+describe('findShiftConflict', () => {
+  const baseShift = {
+    startISO: '2024-01-01T09:00:00.000Z',
+    endISO: '2024-01-01T17:00:00.000Z'
+  } as const;
+
+  it('returns null when there is no conflict', () => {
+    const result = findShiftConflict(baseShift, [
+      {
+        startISO: '2024-01-02T09:00:00.000Z',
+        endISO: '2024-01-02T17:00:00.000Z'
+      }
+    ]);
+
+    expect(result).toEqual({ type: null });
+  });
+
+  it('detects duplicates with identical start and end', () => {
+    const duplicate = findShiftConflict(baseShift, [
+      {
+        startISO: '2024-01-01T09:00:00.000Z',
+        endISO: '2024-01-01T17:00:00.000Z'
+      }
+    ]);
+
+    expect(duplicate.type).toBe('duplicate');
+  });
+
+  it('detects overlapping spans', () => {
+    const overlap = findShiftConflict(baseShift, [
+      {
+        startISO: '2024-01-01T13:00:00.000Z',
+        endISO: '2024-01-01T19:00:00.000Z'
+      }
+    ]);
+
+    expect(overlap.type).toBe('overlap');
+  });
+});


### PR DESCRIPTION
## Summary
- add conflict detection logic to skip duplicate or overlapping CSV rows when importing shifts
- redesign the import modal to show a per-row results table with statuses and downloadable logs
- expand CSV parsing metadata and unit tests to surface source line numbers during import review

## Testing
- npm test
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dcc4f76b348331b193117e422aa712