### PR TITLE
Update settings navigation and relocate data tools

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { useState } from 'react';
+import { ReactNode } from 'react';
 import { BrowserRouter, NavLink, Route, Routes } from 'react-router-dom';
 import { getSettings } from './db/repo';
 import SummaryPage from './routes/SummaryPage';
@@ -7,10 +7,9 @@ import ShiftsPage from './routes/ShiftsPage';
 import SettingsPage from './routes/SettingsPage';
 import { useSettings } from './state/SettingsContext';
 import NotificationManager from './state/NotificationManager';
-import ImportExportModal from './components/ImportExportModal';
-import BackupRestoreModal from './components/BackupRestoreModal';
+import { Cog6ToothIcon } from '@heroicons/react/24/outline';
 
-function NavigationLink({ to, label }: { to: string; label: string }) {
+function NavigationLink({ to, children, label }: { to: string; children: ReactNode; label?: string }) {
   return (
     <NavLink
       to={to}
@@ -21,16 +20,16 @@ function NavigationLink({ to, label }: { to: string; label: string }) {
             : 'text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100'
         }`
       }
+      aria-label={label}
+      title={label}
     >
-      {label}
+      {children}
     </NavLink>
   );
 }
 
 function Layout() {
   const { settings } = useSettings();
-  const [isImportExportOpen, setIsImportExportOpen] = useState(false);
-  const [isBackupModalOpen, setBackupModalOpen] = useState(false);
   useQuery({
     queryKey: ['settings'],
     queryFn: getSettings,
@@ -49,23 +48,16 @@ function Layout() {
             </p>
           </div>
           <nav className="flex flex-wrap items-center justify-start gap-2 sm:justify-end">
-            <NavigationLink to="/" label="Summary" />
-            <NavigationLink to="/shifts" label="Shifts" />
-            <NavigationLink to="/settings" label="Settings" />
-            <button
-              type="button"
-              onClick={() => setBackupModalOpen(true)}
-              className="px-4 py-2 text-sm font-medium text-slate-500 transition-colors hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100"
-            >
-              Backup/Restore
-            </button>
-            <button
-              type="button"
-              onClick={() => setIsImportExportOpen(true)}
-              className="px-4 py-2 text-sm font-medium text-slate-500 transition-colors hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100"
-            >
-              Import/Export
-            </button>
+            <NavigationLink to="/" label="Summary">
+              Summary
+            </NavigationLink>
+            <NavigationLink to="/shifts" label="Shifts">
+              Shifts
+            </NavigationLink>
+            <NavigationLink to="/settings" label="Settings">
+              <span className="sr-only">Settings</span>
+              <Cog6ToothIcon className="h-5 w-5" aria-hidden />
+            </NavigationLink>
           </nav>
         </div>
       </header>
@@ -76,14 +68,6 @@ function Layout() {
           <Route path="/settings" element={<SettingsPage />} />
         </Routes>
       </main>
-      <ImportExportModal
-        isOpen={isImportExportOpen}
-        onClose={() => setIsImportExportOpen(false)}
-      />
-      <BackupRestoreModal
-        isOpen={isBackupModalOpen}
-        onClose={() => setBackupModalOpen(false)}
-      />
     </div>
   );
 }

--- a/src/app/routes/SettingsPage.tsx
+++ b/src/app/routes/SettingsPage.tsx
@@ -2,6 +2,8 @@ import { useEffect, useMemo, useState } from 'react';
 import { useSettings } from '../state/SettingsContext';
 import type { ThemePreference, WeekStart, Weekday } from '../db/schema';
 import { fetchPublicHolidays, fetchPublicHolidayRegions, type HolidayRegion } from '../logic/publicHolidays';
+import ImportExportModal from '../components/ImportExportModal';
+import BackupRestoreModal from '../components/BackupRestoreModal';
 
 const WEEK_START_OPTIONS: Array<{ value: WeekStart; label: string }> = [
   { value: 0, label: 'Sunday' },
@@ -123,6 +125,8 @@ export default function SettingsPage() {
   const [status, setStatus] = useState<string | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
+  const [isImportExportOpen, setIsImportExportOpen] = useState(false);
+  const [isBackupModalOpen, setIsBackupModalOpen] = useState(false);
 
   useEffect(() => {
     if (settings) {
@@ -227,6 +231,28 @@ export default function SettingsPage() {
   return (
     <section className="max-w-xl rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
       <h2 className="mb-4 text-lg font-semibold text-slate-900 dark:text-slate-50">Settings</h2>
+      <div className="mb-6 rounded-xl border border-slate-200 bg-slate-50/60 p-4 dark:border-slate-800 dark:bg-slate-900/60">
+        <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">Data management</h3>
+        <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+          Backup or export your data, or restore and import from a saved file.
+        </p>
+        <div className="mt-3 flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => setIsImportExportOpen(true)}
+            className="inline-flex items-center rounded-full border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 dark:border-slate-700 dark:text-slate-100 dark:hover:bg-slate-800 dark:focus-visible:ring-offset-slate-900"
+          >
+            Import / Export
+          </button>
+          <button
+            type="button"
+            onClick={() => setIsBackupModalOpen(true)}
+            className="inline-flex items-center rounded-full border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 dark:border-slate-700 dark:text-slate-100 dark:hover:bg-slate-800 dark:focus-visible:ring-offset-slate-900"
+          >
+            Backup / Restore
+          </button>
+        </div>
+      </div>
       <form
         className="flex flex-col gap-5"
         onSubmit={async (event) => {
@@ -600,6 +626,8 @@ export default function SettingsPage() {
         {formError && <p className="text-xs text-red-500">{formError}</p>}
         {status && <p className="text-xs text-emerald-500">{status}</p>}
       </form>
+      <ImportExportModal isOpen={isImportExportOpen} onClose={() => setIsImportExportOpen(false)} />
+      <BackupRestoreModal isOpen={isBackupModalOpen} onClose={() => setIsBackupModalOpen(false)} />
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- replace the Settings navigation text with a gear icon while keeping accessible labelling
- remove backup/restore and import/export buttons from the global navigation
- surface backup/restore and import/export controls at the top of the Settings page with inline modals

## Testing
- npm run lint *(fails: ESLint 9 requires eslint.config.js and the project still uses .eslintrc configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd3d8a4bc8331b93682d9c06adc90