### PR TITLE
feat: refresh Chrona branding

### DIFF
--- a/public/chrona-logo.svg
+++ b/public/chrona-logo.svg
@@ -1,26 +1,32 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Chrona apple touch icon">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Chrona logo">
   <defs>
-    <radialGradient id="chrona-apple-glow" cx="50%" cy="40%" r="60%">
+    <radialGradient id="chrona-glow" cx="50%" cy="40%" r="60%">
       <stop offset="0%" stop-color="#9a4efb" stop-opacity="0.95" />
       <stop offset="45%" stop-color="#5a6ffb" stop-opacity="0.88" />
-      <stop offset="100%" stop-color="#1b1f2f" stop-opacity="0.08" />
+      <stop offset="100%" stop-color="#1b1f2f" stop-opacity="0.05" />
     </radialGradient>
-    <linearGradient id="chrona-apple-ring" x1="25%" y1="15%" x2="80%" y2="85%">
+    <linearGradient id="chrona-ring" x1="25%" y1="15%" x2="80%" y2="85%">
+      <stop offset="0%" stop-color="#9a4efb" />
+      <stop offset="50%" stop-color="#6f68ff" />
+      <stop offset="100%" stop-color="#2ec5ff" />
+    </linearGradient>
+    <linearGradient id="chrona-hand" x1="30%" y1="25%" x2="75%" y2="85%">
       <stop offset="0%" stop-color="#9a4efb" />
       <stop offset="100%" stop-color="#2ec5ff" />
     </linearGradient>
-    <linearGradient id="chrona-apple-hand" x1="30%" y1="20%" x2="78%" y2="90%">
-      <stop offset="0%" stop-color="#9a4efb" />
-      <stop offset="100%" stop-color="#2ec5ff" />
-    </linearGradient>
+    <filter id="chrona-soft-glow" x="-40%" y="-40%" width="180%" height="180%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="32" result="blur" />
+    </filter>
   </defs>
-  <rect width="512" height="512" rx="120" fill="#10131d" />
-  <circle cx="256" cy="234" r="190" fill="url(#chrona-apple-glow)" />
+  <rect width="512" height="512" rx="128" fill="#10131d" />
+  <g filter="url(#chrona-soft-glow)">
+    <circle cx="256" cy="232" r="192" fill="url(#chrona-glow)" />
+  </g>
   <circle cx="256" cy="256" r="188" fill="#10131d" />
   <path
     d="M256 104a152 152 0 1 0 107.6 44.6"
     fill="none"
-    stroke="url(#chrona-apple-ring)"
+    stroke="url(#chrona-ring)"
     stroke-width="56"
     stroke-linecap="round"
   />
@@ -34,6 +40,6 @@
   />
   <path
     d="M256 152c-11 0-20 9-20 20v92l-57.7-32.3a16 16 0 0 0-15.6 27.8l91.6 51.3a20 20 0 0 0 29.7-17.4V172c0-11-9-20-20-20z"
-    fill="url(#chrona-apple-hand)"
+    fill="url(#chrona-hand)"
   />
 </svg>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,4 +1,39 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
-  <rect width="64" height="64" rx="16" fill="#0f172a" />
-  <path d="M20 20h24v8H20zM20 34h24v10H20z" fill="#f8fafc" />
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" role="img" aria-label="Chrona favicon">
+  <defs>
+    <radialGradient id="chrona-favicon-glow" cx="50%" cy="40%" r="70%">
+      <stop offset="0%" stop-color="#9a4efb" stop-opacity="0.95" />
+      <stop offset="50%" stop-color="#5a6ffb" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#151929" stop-opacity="0.2" />
+    </radialGradient>
+    <linearGradient id="chrona-favicon-ring" x1="15%" y1="10%" x2="85%" y2="90%">
+      <stop offset="0%" stop-color="#9a4efb" />
+      <stop offset="100%" stop-color="#2ec5ff" />
+    </linearGradient>
+    <linearGradient id="chrona-favicon-hand" x1="25%" y1="20%" x2="80%" y2="90%">
+      <stop offset="0%" stop-color="#9a4efb" />
+      <stop offset="100%" stop-color="#2ec5ff" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="16" fill="#10131d" />
+  <circle cx="32" cy="30" r="28" fill="url(#chrona-favicon-glow)" />
+  <circle cx="32" cy="32" r="27" fill="#10131d" />
+  <path
+    d="M32 12a20 20 0 1 0 14.2 5.9"
+    fill="none"
+    stroke="url(#chrona-favicon-ring)"
+    stroke-width="7"
+    stroke-linecap="round"
+  />
+  <path
+    d="M32 12a20 20 0 0 0-20 20c0 4.2 1.2 8.1 3.4 11.6"
+    fill="none"
+    stroke="#151929"
+    stroke-width="7"
+    stroke-linecap="round"
+    opacity="0.35"
+  />
+  <path
+    d="M32 16c-1.5 0-2.8 1.3-2.8 2.8v12.5l-7.8-4.4a2.8 2.8 0 1 0-2.7 4.8l12.3 6.9a3.2 3.2 0 0 0 4.8-2.8V18.8c0-1.5-1.3-2.8-2.8-2.8z"
+    fill="url(#chrona-favicon-hand)"
+  />
 </svg>

--- a/public/pwa-icon-maskable.svg
+++ b/public/pwa-icon-maskable.svg
@@ -1,41 +1,39 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Chrona maskable icon">
   <defs>
-    <linearGradient id="chrona-bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#111827" />
-      <stop offset="100%" stop-color="#1f2937" />
+    <radialGradient id="chrona-maskable-glow" cx="50%" cy="40%" r="65%">
+      <stop offset="0%" stop-color="#9a4efb" stop-opacity="0.95" />
+      <stop offset="45%" stop-color="#5a6ffb" stop-opacity="0.88" />
+      <stop offset="100%" stop-color="#1b1f2f" stop-opacity="0.12" />
+    </radialGradient>
+    <linearGradient id="chrona-maskable-ring" x1="25%" y1="15%" x2="80%" y2="85%">
+      <stop offset="0%" stop-color="#9a4efb" />
+      <stop offset="100%" stop-color="#2ec5ff" />
     </linearGradient>
-    <linearGradient id="chrona-accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#38bdf8" />
-      <stop offset="100%" stop-color="#6366f1" />
+    <linearGradient id="chrona-maskable-hand" x1="30%" y1="20%" x2="78%" y2="90%">
+      <stop offset="0%" stop-color="#9a4efb" />
+      <stop offset="100%" stop-color="#2ec5ff" />
     </linearGradient>
   </defs>
-  <rect width="512" height="512" rx="150" fill="url(#chrona-bg)" />
+  <rect width="512" height="512" fill="#10131d" />
+  <circle cx="256" cy="230" r="206" fill="url(#chrona-maskable-glow)" />
+  <circle cx="256" cy="256" r="204" fill="#10131d" />
   <path
-    d="M360 148a148 148 0 1 0 0 216"
+    d="M256 96a168 168 0 1 0 118.9 49.3"
     fill="none"
-    stroke="#e2e8f0"
-    stroke-width="58"
+    stroke="url(#chrona-maskable-ring)"
+    stroke-width="60"
     stroke-linecap="round"
-    stroke-linejoin="round"
-    opacity="0.9"
   />
   <path
-    d="M360 148a148 148 0 0 0 0 216"
+    d="M256 96a168 168 0 0 0-168 168c0 34.7 11.3 66.8 30.7 93"
     fill="none"
-    stroke="url(#chrona-accent)"
-    stroke-width="34"
+    stroke="#151929"
+    stroke-width="60"
     stroke-linecap="round"
-    stroke-linejoin="round"
-    opacity="0.9"
+    opacity="0.35"
   />
-  <circle cx="256" cy="256" r="32" fill="#0ea5e9" />
   <path
-    d="M256 184v92l78 42"
-    fill="none"
-    stroke="url(#chrona-accent)"
-    stroke-width="28"
-    stroke-linecap="round"
-    stroke-linejoin="round"
+    d="M256 148c-12.1 0-22 9.9-22 22v102l-66.8-37.3c-7.4-4.1-16.8-1.4-20.9 6.1-4.1 7.4-1.4 16.8 6.1 20.9l102.3 57.3a22 22 0 0 0 32.7-19.1V170c0-12.1-9.9-22-22-22z"
+    fill="url(#chrona-maskable-hand)"
   />
-  <circle cx="256" cy="256" r="18" fill="#f8fafc" />
 </svg>

--- a/public/pwa-icon.svg
+++ b/public/pwa-icon.svg
@@ -1,41 +1,39 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Chrona icon">
   <defs>
-    <linearGradient id="chrona-bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#111827" />
-      <stop offset="100%" stop-color="#1f2937" />
+    <radialGradient id="chrona-pwa-glow" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#9a4efb" stop-opacity="0.95" />
+      <stop offset="45%" stop-color="#5a6ffb" stop-opacity="0.88" />
+      <stop offset="100%" stop-color="#1b1f2f" stop-opacity="0.08" />
+    </radialGradient>
+    <linearGradient id="chrona-pwa-ring" x1="25%" y1="15%" x2="80%" y2="85%">
+      <stop offset="0%" stop-color="#9a4efb" />
+      <stop offset="100%" stop-color="#2ec5ff" />
     </linearGradient>
-    <linearGradient id="chrona-accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#38bdf8" />
-      <stop offset="100%" stop-color="#6366f1" />
+    <linearGradient id="chrona-pwa-hand" x1="30%" y1="20%" x2="78%" y2="90%">
+      <stop offset="0%" stop-color="#9a4efb" />
+      <stop offset="100%" stop-color="#2ec5ff" />
     </linearGradient>
   </defs>
-  <rect width="512" height="512" rx="112" fill="url(#chrona-bg)" />
+  <rect width="512" height="512" rx="112" fill="#10131d" />
+  <circle cx="256" cy="234" r="190" fill="url(#chrona-pwa-glow)" />
+  <circle cx="256" cy="256" r="188" fill="#10131d" />
   <path
-    d="M360 148a148 148 0 1 0 0 216"
+    d="M256 104a152 152 0 1 0 107.6 44.6"
     fill="none"
-    stroke="#e2e8f0"
-    stroke-width="58"
+    stroke="url(#chrona-pwa-ring)"
+    stroke-width="56"
     stroke-linecap="round"
-    stroke-linejoin="round"
-    opacity="0.9"
   />
   <path
-    d="M360 148a148 148 0 0 0 0 216"
+    d="M256 104a152 152 0 0 0-152 152c0 32 10.3 61.6 27.7 85.6"
     fill="none"
-    stroke="url(#chrona-accent)"
-    stroke-width="34"
+    stroke="#151929"
+    stroke-width="56"
     stroke-linecap="round"
-    stroke-linejoin="round"
-    opacity="0.9"
+    opacity="0.35"
   />
-  <circle cx="256" cy="256" r="32" fill="#0ea5e9" />
   <path
-    d="M256 184v92l78 42"
-    fill="none"
-    stroke="url(#chrona-accent)"
-    stroke-width="28"
-    stroke-linecap="round"
-    stroke-linejoin="round"
+    d="M256 152c-11 0-20 9-20 20v92l-57.7-32.3a16 16 0 0 0-15.6 27.8l91.6 51.3a20 20 0 0 0 29.7-17.4V172c0-11-9-20-20-20z"
+    fill="url(#chrona-pwa-hand)"
   />
-  <circle cx="256" cy="256" r="18" fill="#f8fafc" />
 </svg>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -41,11 +41,20 @@ function Layout() {
       <NotificationManager />
       <header className="sticky top-0 z-10 border-b border-slate-200/60 bg-white/80 backdrop-blur dark:border-slate-800/60 dark:bg-slate-900/80">
         <div className="mx-auto flex max-w-4xl flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex flex-col gap-1">
-            <h1 className="text-xl font-semibold">Chrona</h1>
-            <p className="text-xs text-slate-500 dark:text-slate-400">
-              Precision shift tracking for people who live by the clock
-            </p>
+          <div className="flex items-start gap-3">
+            <img
+              src="/chrona-logo.svg"
+              alt="Chrona logo"
+              className="h-12 w-12 flex-shrink-0 drop-shadow-sm"
+              width="48"
+              height="48"
+            />
+            <div className="flex flex-col gap-1">
+              <h1 className="text-xl font-semibold">Chrona</h1>
+              <p className="text-xs text-slate-500 dark:text-slate-400">
+                Precision shift tracking for people who live by the clock
+              </p>
+            </div>
           </div>
           <nav className="flex flex-wrap items-center justify-start gap-2 sm:justify-end">
             <NavigationLink to="/" label="Summary">


### PR DESCRIPTION
## Summary
- add a vector Chrona logo with gradient glow that matches the supplied artwork
- replace all favicon and PWA icon assets with the new logo treatment
- surface the new logo in the in-app header for consistent branding

## Testing
- npm run build *(fails: missing optional dependencies @gera2ld/tarjs and fflate type declarations in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68dcdcbde82c8331af690e44919e602e