### PR TITLE
refactor: promote shift creation controls

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -7,14 +7,15 @@ import ShiftsPage from './routes/ShiftsPage';
 import SettingsPage from './routes/SettingsPage';
 import { useSettings } from './state/SettingsContext';
 import NotificationManager from './state/NotificationManager';
-import { Cog6ToothIcon } from '@heroicons/react/24/outline';
+import { CalendarDaysIcon, ChartPieIcon, Cog6ToothIcon, PlusCircleIcon } from '@heroicons/react/24/outline';
+import { ShiftCreationProvider, useShiftCreation } from './state/ShiftCreationContext';
 
 function NavigationLink({ to, children, label }: { to: string; children: ReactNode; label?: string }) {
   return (
     <NavLink
       to={to}
       className={({ isActive }) =>
-        `px-4 py-2 rounded-full text-sm font-medium transition-colors ${
+        `inline-flex h-10 w-10 items-center justify-center rounded-full text-sm font-medium transition-colors ${
           isActive
             ? 'bg-primary text-primary-foreground shadow'
             : 'text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100'
@@ -30,6 +31,7 @@ function NavigationLink({ to, children, label }: { to: string; children: ReactNo
 
 function Layout() {
   const { settings } = useSettings();
+  const { openCreateModal } = useShiftCreation();
   useQuery({
     queryKey: ['settings'],
     queryFn: getSettings,
@@ -49,11 +51,23 @@ function Layout() {
           </div>
           <nav className="flex flex-wrap items-center justify-start gap-2 sm:justify-end">
             <NavigationLink to="/" label="Summary">
-              Summary
+              <span className="sr-only">Summary</span>
+              <ChartPieIcon className="h-5 w-5" aria-hidden />
             </NavigationLink>
             <NavigationLink to="/shifts" label="Shifts">
-              Shifts
+              <span className="sr-only">Shifts</span>
+              <CalendarDaysIcon className="h-5 w-5" aria-hidden />
             </NavigationLink>
+            <button
+              type="button"
+              onClick={openCreateModal}
+              disabled={!settings}
+              className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-primary text-primary-foreground shadow transition hover:bg-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white disabled:opacity-60 disabled:hover:bg-primary dark:focus-visible:ring-offset-slate-900"
+              aria-label="Add shift"
+              title="Add shift"
+            >
+              <PlusCircleIcon className="h-6 w-6" aria-hidden />
+            </button>
             <NavigationLink to="/settings" label="Settings">
               <span className="sr-only">Settings</span>
               <Cog6ToothIcon className="h-5 w-5" aria-hidden />
@@ -75,7 +89,9 @@ function Layout() {
 export default function App() {
   return (
     <BrowserRouter>
-      <Layout />
+      <ShiftCreationProvider>
+        <Layout />
+      </ShiftCreationProvider>
     </BrowserRouter>
   );
 }

--- a/src/app/routes/SettingsPage.tsx
+++ b/src/app/routes/SettingsPage.tsx
@@ -230,6 +230,7 @@ export default function SettingsPage() {
 
   return (
     <section className="max-w-xl rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <h1 className="sr-only">Settings</h1>
       <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-50">Chrona preferences</h2>
       <p className="mb-4 text-sm text-slate-500 dark:text-slate-400">
         Tune pay rates, notifications, and penalty windows so Chrona mirrors the way you work.

--- a/src/app/routes/ShiftsPage.tsx
+++ b/src/app/routes/ShiftsPage.tsx
@@ -12,15 +12,10 @@ import {
   startOfMonth,
   startOfWeek
 } from 'date-fns';
-import {
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  PlusIcon,
-  TrashIcon
-} from '@heroicons/react/24/outline';
+import { ChevronLeftIcon, ChevronRightIcon, TrashIcon } from '@heroicons/react/24/outline';
 import Modal from '../components/Modal';
-import ShiftForm, { type ShiftFormValues } from '../components/ShiftForm';
-import { createShift, deleteShift, getAllShifts, updateShift } from '../db/repo';
+import type { ShiftFormValues } from '../components/ShiftForm';
+import { deleteShift, getAllShifts, updateShift } from '../db/repo';
 import type { Shift, WeekStart } from '../db/schema';
 import { useSettings } from '../state/SettingsContext';
 import { useTimeFormatter } from '../state/useTimeFormatter';
@@ -76,7 +71,6 @@ export const CALENDAR_WEEK_START: WeekStart = 1;
 export default function ShiftsPage() {
   const queryClient = useQueryClient();
   const { settings } = useSettings();
-  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [editingShift, setEditingShift] = useState<Shift | null>(null);
   const [currentMonth, setCurrentMonth] = useState(() => startOfMonth(new Date()));
   const [selectedDate, setSelectedDate] = useState<Date>(() => new Date());
@@ -128,20 +122,6 @@ export default function ShiftsPage() {
 
     return grouped;
   }, [shifts]);
-
-  const createMutation = useMutation({
-    mutationFn: async (values: ShiftFormValues) => {
-      if (!settings) throw new Error('Settings not loaded');
-      return createShift({ startISO: values.start, endISO: values.end, note: values.note }, settings);
-    },
-    onSuccess: async () => {
-      setIsCreateModalOpen(false);
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['shifts'] }),
-        queryClient.invalidateQueries({ queryKey: ['summary'] })
-      ]);
-    }
-  });
 
   const updateMutation = useMutation({
     mutationFn: async ({ shift, values }: { shift: Shift; values: ShiftFormValues }) => {
@@ -245,16 +225,6 @@ export default function ShiftsPage() {
             className="rounded-full border border-slate-200 px-3 py-1 text-sm font-medium text-slate-600 transition hover:border-primary hover:text-primary dark:border-slate-700 dark:text-slate-200"
           >
             Today
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              setIsCreateModalOpen(true);
-            }}
-            className="flex flex-1 items-center justify-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow transition hover:bg-slate-900 sm:flex-none"
-          >
-            <PlusIcon className="h-5 w-5" aria-hidden="true" />
-            Add shift
           </button>
         </div>
       </header>
@@ -377,24 +347,9 @@ export default function ShiftsPage() {
 
       {!isLoading && shifts.length === 0 && (
         <p className="text-sm text-slate-500 dark:text-slate-400">
-          Chrona hasn't logged any shifts yet. Tap “Add shift” to start building your timeline.
+          Chrona hasn't logged any shifts yet. Use the plus button in the top menu to start building your timeline.
         </p>
       )}
-
-      <Modal
-        isOpen={isCreateModalOpen}
-        onClose={() => setIsCreateModalOpen(false)}
-        title="Add a shift"
-      >
-        <ShiftForm
-          key={isCreateModalOpen ? 'create-open' : 'create-closed'}
-          onSubmit={async (values) => {
-            await createMutation.mutateAsync(values);
-          }}
-          onCancel={() => setIsCreateModalOpen(false)}
-          submitLabel="Save shift"
-        />
-      </Modal>
 
       <Modal isOpen={Boolean(editingShift)} onClose={() => setEditingShift(null)} title="Shift details">
         {editingShift && (

--- a/src/app/state/ShiftCreationContext.tsx
+++ b/src/app/state/ShiftCreationContext.tsx
@@ -1,0 +1,77 @@
+import { ReactNode, createContext, useContext, useMemo, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import Modal from '../components/Modal';
+import ShiftForm, { type ShiftFormValues } from '../components/ShiftForm';
+import { createShift } from '../db/repo';
+import { useSettings } from './SettingsContext';
+
+export type ShiftCreationContextValue = {
+  openCreateModal: () => void;
+  closeCreateModal: () => void;
+  isCreateModalOpen: boolean;
+};
+
+const ShiftCreationContext = createContext<ShiftCreationContextValue | undefined>(undefined);
+
+export function ShiftCreationProvider({ children }: { children: ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const queryClient = useQueryClient();
+  const { settings } = useSettings();
+
+  const createMutation = useMutation({
+    mutationFn: async (values: ShiftFormValues) => {
+      if (!settings) {
+        throw new Error('Settings are not ready yet.');
+      }
+      return createShift({ startISO: values.start, endISO: values.end, note: values.note }, settings);
+    },
+    onSuccess: async () => {
+      setIsOpen(false);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['shifts'] }),
+        queryClient.invalidateQueries({ queryKey: ['summary'] })
+      ]);
+    }
+  });
+
+  const openCreateModal = () => {
+    setIsOpen(true);
+  };
+
+  const closeCreateModal = () => {
+    setIsOpen(false);
+  };
+
+  const value = useMemo<ShiftCreationContextValue>(
+    () => ({
+      openCreateModal,
+      closeCreateModal,
+      isCreateModalOpen: isOpen
+    }),
+    [isOpen]
+  );
+
+  return (
+    <ShiftCreationContext.Provider value={value}>
+      {children}
+      <Modal isOpen={isOpen} onClose={closeCreateModal} title="Add a shift">
+        <ShiftForm
+          key={isOpen ? 'create-open' : 'create-closed'}
+          onSubmit={async (values) => {
+            await createMutation.mutateAsync(values);
+          }}
+          onCancel={closeCreateModal}
+          submitLabel="Save shift"
+        />
+      </Modal>
+    </ShiftCreationContext.Provider>
+  );
+}
+
+export function useShiftCreation() {
+  const context = useContext(ShiftCreationContext);
+  if (!context) {
+    throw new Error('useShiftCreation must be used within a ShiftCreationProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- convert the top navigation to use icons, including a new add-shift control in the header
- centralize the shift creation modal logic in a shared provider available across pages
- improve settings page accessibility with a hidden heading while updating copy references

## Testing
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68dcde5972b0833199bfcffe9bde182c