### PR TITLE
Add favicon.ico to PWA asset precache list

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     react(),
     VitePWA({
       registerType: 'autoUpdate',
-      includeAssets: ['favicon.svg', 'robots.txt', 'apple-touch-icon.svg'],
+      includeAssets: ['favicon.svg', 'favicon.ico', 'robots.txt', 'apple-touch-icon.svg'],
       workbox: {
         clientsClaim: true,
         skipWaiting: true,


### PR DESCRIPTION
## Summary
- include the favicon.ico file in the VitePWA includeAssets configuration so it is precached by the service worker

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dce9754aa08331862767f439d4e835