### PR TITLE
Remove divider above settings action button

### DIFF
--- a/src/app/routes/SettingsPage.tsx
+++ b/src/app/routes/SettingsPage.tsx
@@ -345,7 +345,7 @@ export default function SettingsPage() {
   };
 
   const renderFormActions = () => (
-    <div className="mt-10 flex w-full flex-col items-center gap-2 border-t border-neutral-200 pt-6 text-center dark:border-midnight-700">
+    <div className="mt-10 flex w-full flex-col items-center gap-2 pt-6 text-center">
       <button
         type="submit"
         form="settings-form"


### PR DESCRIPTION
## Summary
- remove the horizontal divider above the Save settings button on the Settings page for a cleaner layout

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dceec6196c8331bbd646590e92f3ab