### PR TITLE
Improve shift form validation and tests

### DIFF
--- a/src/app/utils/datetime.ts
+++ b/src/app/utils/datetime.ts
@@ -1,5 +1,17 @@
 const pad = (value: number) => value.toString().padStart(2, '0');
 
+const TIME_24_HOUR_PATTERN = /^([01]?\d|2[0-3]):([0-5]\d)$/;
+const TIME_12_HOUR_PATTERN = /^(0?[1-9]|1[0-2]):([0-5]\d)\s*([AaPp][Mm])$/;
+
+const TWENTY_FOUR_HOUR_LABEL = 'HH:MM (24-hour)';
+const TWELVE_HOUR_LABEL = 'HH:MM AM/PM (12-hour)';
+
+function to12HourLabel(hours: number) {
+  const suffix = hours >= 12 ? 'PM' : 'AM';
+  const normalizedHours = hours % 12 || 12;
+  return { suffix, hours: normalizedHours };
+}
+
 function ensureValid(date: Date) {
   if (Number.isNaN(date.getTime())) {
     throw new Error('Invalid date value');
@@ -22,6 +34,11 @@ export function toLocalTimeInput(iso: string) {
   return `${pad(date.getHours())}:${pad(date.getMinutes())}`;
 }
 
+export function formatTimeForInput(iso: string, use24HourTime: boolean) {
+  const normalized = toLocalTimeInput(iso);
+  return use24HourTime ? normalized : formatNormalizedTime(normalized, false);
+}
+
 export function nowLocalInputValue() {
   const now = new Date();
   now.setSeconds(0, 0);
@@ -40,6 +57,11 @@ export function nowLocalTimeInputValue() {
   return toLocalTimeInput(now.toISOString());
 }
 
+export function nowTimeInputForMode(use24HourTime: boolean) {
+  const normalized = nowLocalTimeInputValue();
+  return use24HourTime ? normalized : formatNormalizedTime(normalized, false);
+}
+
 export function toISO(value: string) {
   const date = ensureValid(new Date(value));
   return date.toISOString();
@@ -50,4 +72,74 @@ export function createDateFromLocalInputs(date: string, time: string) {
   const parsed = ensureValid(new Date(combined));
   parsed.setSeconds(0, 0);
   return parsed;
+}
+
+export function formatNormalizedTime(time: string, use24HourTime: boolean) {
+  if (!TIME_24_HOUR_PATTERN.test(time)) {
+    throw new Error('Time must use HH:MM format');
+  }
+
+  if (use24HourTime) {
+    return time;
+  }
+
+  const [, hoursPart, minutesPart] = time.match(TIME_24_HOUR_PATTERN)!;
+  const hours = Number.parseInt(hoursPart, 10);
+  const { suffix, hours: displayHours } = to12HourLabel(hours);
+  return `${pad(displayHours)}:${minutesPart} ${suffix}`;
+}
+
+function parse24HourTime(value: string) {
+  const match = value.match(TIME_24_HOUR_PATTERN);
+  if (!match) {
+    throw new Error(`Use ${TWENTY_FOUR_HOUR_LABEL}.`);
+  }
+  const [, hours, minutes] = match;
+  return `${pad(Number.parseInt(hours, 10))}:${minutes}`;
+}
+
+function parse12HourTime(value: string) {
+  const match = value.match(TIME_12_HOUR_PATTERN);
+  if (!match) {
+    throw new Error(`Use ${TWELVE_HOUR_LABEL}.`);
+  }
+  const [, hoursPart, minutesPart, suffixPart] = match;
+  const hours = Number.parseInt(hoursPart, 10);
+  const suffix = suffixPart.toLowerCase() as 'am' | 'pm';
+  const normalizedHours = suffix === 'am' ? hours % 12 : (hours % 12) + 12;
+  return `${pad(normalizedHours)}:${minutesPart}`;
+}
+
+export function parseTimeInput(value: string, use24HourTime: boolean) {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error('Enter a time value.');
+  }
+
+  if (use24HourTime) {
+    return parse24HourTime(trimmed);
+  }
+
+  try {
+    return parse12HourTime(trimmed);
+  } catch (error) {
+    throw new Error((error as Error).message);
+  }
+}
+
+export function tryNormalizeTimeInput(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    return parse24HourTime(trimmed);
+  } catch (error24) {
+    try {
+      return parse12HourTime(trimmed);
+    } catch (error12) {
+      return null;
+    }
+  }
 }

--- a/src/tests/utils/datetime.test.ts
+++ b/src/tests/utils/datetime.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatNormalizedTime,
+  parseTimeInput,
+  tryNormalizeTimeInput
+} from '../../app/utils/datetime';
+
+describe('datetime utils - time input helpers', () => {
+  describe('formatNormalizedTime', () => {
+    it('keeps 24-hour times unchanged when mode is 24-hour', () => {
+      expect(formatNormalizedTime('14:45', true)).toBe('14:45');
+    });
+
+    it('converts 24-hour times to 12-hour display strings', () => {
+      expect(formatNormalizedTime('14:45', false)).toBe('02:45 PM');
+      expect(formatNormalizedTime('00:10', false)).toBe('12:10 AM');
+    });
+  });
+
+  describe('parseTimeInput', () => {
+    it('accepts 24-hour formatted input when required', () => {
+      expect(parseTimeInput('23:59', true)).toBe('23:59');
+    });
+
+    it('accepts 12-hour formatted input when required', () => {
+      expect(parseTimeInput('2:15 pm', false)).toBe('14:15');
+      expect(parseTimeInput('02:15 AM', false)).toBe('02:15');
+    });
+
+    it('rejects invalid input', () => {
+      expect(() => parseTimeInput('25:00', true)).toThrow(/24-hour/);
+      expect(() => parseTimeInput('14:00', false)).toThrow(/12-hour/);
+    });
+  });
+
+  describe('tryNormalizeTimeInput', () => {
+    it('normalizes 24-hour input', () => {
+      expect(tryNormalizeTimeInput('05:30')).toBe('05:30');
+    });
+
+    it('normalizes 12-hour input', () => {
+      expect(tryNormalizeTimeInput('7:45 pm')).toBe('19:45');
+    });
+
+    it('returns null for invalid input', () => {
+      expect(tryNormalizeTimeInput('not a time')).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- update the manual shift form to honour the 24-hour clock preference, normalise user input, and surface clearer validation errors before saving
- extend datetime utilities with shared parsing/formatting helpers and cover them with unit tests
- tweak the settings page to expose a “Settings” heading and keep form actions within each tabbed form so automated tests can interact with hidden inputs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcf37e95b88331b1d50c6ffbe783b4