### PR TITLE
Respect 24-hour clock preference across time displays

### DIFF
--- a/src/app/routes/ShiftsPage.tsx
+++ b/src/app/routes/ShiftsPage.tsx
@@ -18,7 +18,7 @@ import type { ShiftFormValues } from '../components/ShiftForm';
 import { deleteShift, getAllShifts, updateShift } from '../db/repo';
 import type { Shift, WeekStart } from '../db/schema';
 import { useSettings } from '../state/SettingsContext';
-import { useTimeFormatter } from '../state/useTimeFormatter';
+import { useDateTimeFormatter, useTimeFormatter } from '../state/useTimeFormatter';
 import { toISO, toLocalDateTimeInput } from '../utils/datetime';
 
 function ShiftSummaryCard({
@@ -81,6 +81,7 @@ export default function ShiftsPage() {
   });
 
   const timeFormatter = useTimeFormatter();
+  const dateTimeFormatter = useDateTimeFormatter();
   const currencyFormatter = useMemo(() => {
     const currency = settings?.currency && settings.currency.trim() ? settings.currency : 'USD';
     return new Intl.NumberFormat(undefined, {
@@ -381,8 +382,10 @@ export default function ShiftsPage() {
               </div>
               <div className="grid gap-1 text-sm text-neutral-600 dark:text-neutral-200">
                 <span className="font-medium text-neutral-700 dark:text-neutral-100">Summary</span>
-                <span>{format(new Date(editingShift.startISO), 'PPpp')}</span>
-                {editingShift.endISO && <span>Ends {format(new Date(editingShift.endISO), 'PPpp')}</span>}
+                <span>{dateTimeFormatter.format(new Date(editingShift.startISO))}</span>
+                {editingShift.endISO && (
+                  <span>Ends {dateTimeFormatter.format(new Date(editingShift.endISO))}</span>
+                )}
                 <span>
                   Base: {(editingShift.baseMinutes / 60).toFixed(2)}h · Penalty: {(editingShift.penaltyMinutes / 60).toFixed(2)}h
                 </span>

--- a/src/app/state/NotificationManager.tsx
+++ b/src/app/state/NotificationManager.tsx
@@ -9,7 +9,8 @@ function formatShiftTime(date: Date, use24HourTime: boolean): string {
   return new Intl.DateTimeFormat(undefined, {
     hour: 'numeric',
     minute: '2-digit',
-    hour12: !use24HourTime
+    hour12: !use24HourTime,
+    hourCycle: use24HourTime ? 'h23' : 'h12'
   }).format(date);
 }
 

--- a/src/app/state/useTimeFormatter.ts
+++ b/src/app/state/useTimeFormatter.ts
@@ -3,14 +3,30 @@ import { useSettings } from './SettingsContext';
 
 export function useTimeFormatter() {
   const { settings } = useSettings();
+  const use24HourTime = Boolean(settings?.use24HourTime);
   return useMemo(
     () =>
       new Intl.DateTimeFormat(undefined, {
         hour: '2-digit',
         minute: '2-digit',
-        hour12: settings?.use24HourTime ? false : undefined,
-        hourCycle: settings?.use24HourTime ? 'h23' : undefined
+        hour12: !use24HourTime,
+        hourCycle: use24HourTime ? 'h23' : 'h12'
       }),
-    [settings?.use24HourTime]
+    [use24HourTime]
+  );
+}
+
+export function useDateTimeFormatter() {
+  const { settings } = useSettings();
+  const use24HourTime = Boolean(settings?.use24HourTime);
+  return useMemo(
+    () =>
+      new Intl.DateTimeFormat(undefined, {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+        hour12: !use24HourTime,
+        hourCycle: use24HourTime ? 'h23' : 'h12'
+      }),
+    [use24HourTime]
   );
 }


### PR DESCRIPTION
## Summary
- ensure reusable time and date-time formatters enforce the 24-hour option when enabled
- switch shift detail modal to the new formatter so its timestamps follow the user preference
- align notification time formatting with the selected hour cycle

## Testing
- npm run test -- --run src/tests/routes/ShiftsPage.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dcfaf2d2f88331b655df4cc93551d2