### PR TITLE
Update shift detail modal to reuse shared shift form

### DIFF
--- a/src/app/routes/SettingsPage.tsx
+++ b/src/app/routes/SettingsPage.tsx
@@ -665,7 +665,7 @@ export default function SettingsPage() {
                   />
                 </div>
               </div>
-              {renderFormActions()}
+              {renderFormActions(true)}
             </form>
           ) : null}
 


### PR DESCRIPTION
## Summary
- replace the calendar shift detail modal's ad-hoc inputs with the shared `ShiftForm` so it exposes date, start, finish, and note fields just like the create flow
- keep the modal's shift summary and delete affordance while simplifying state handling and ensuring time inputs follow the 24-hour setting
- fix the settings form actions call site after adjusting the signature to require the `hasActiveForm` flag

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dcfcfe8df08331a0cd8b736117efb1