### PR TITLE
Refine shift card responsive layout

### DIFF
--- a/src/app/components/ShiftCard.tsx
+++ b/src/app/components/ShiftCard.tsx
@@ -26,35 +26,35 @@ export default function ShiftCard({ shift, currency, onEdit, onDelete }: ShiftCa
 
   return (
     <article className="flex flex-col gap-3 rounded-xl border border-neutral-200 bg-white p-4 shadow-sm transition hover:shadow-md dark:border-midnight-800 dark:bg-midnight-900">
-      <header className="flex flex-wrap items-start justify-between gap-y-2 gap-x-3">
-        <div className="min-w-0">
+      <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-3 sm:grid-cols-[minmax(0,1fr)_auto_auto] sm:items-center">
+        <header className="min-w-0">
           <p className="text-sm font-semibold text-neutral-700 dark:text-neutral-100">
             {dateFormatter.format(startDate)}
           </p>
           <p className="text-[11px] text-neutral-500 dark:text-neutral-300 sm:text-xs">
             {timeFormatter.format(startDate)} — {endDate ? timeFormatter.format(endDate) : 'In progress'}
           </p>
-        </div>
-        <p className="ml-auto text-right text-base font-semibold text-neutral-900 dark:text-neutral-50 sm:text-lg">
+        </header>
+        <p className="col-start-2 row-start-1 text-right text-base font-semibold text-neutral-900 dark:text-neutral-50 sm:col-start-3 sm:row-start-1 sm:text-lg">
           {currencyFormatter.format(shift.totalPay)}
         </p>
-      </header>
-      <dl className="grid grid-cols-3 gap-2 text-[11px] sm:text-xs">
-        <div>
-          <dt className="text-neutral-500 dark:text-neutral-300">Base</dt>
-          <dd className="font-medium text-neutral-700 dark:text-neutral-100">{(shift.baseMinutes / 60).toFixed(2)}h</dd>
-        </div>
-        <div>
-          <dt className="text-neutral-500 dark:text-neutral-300">Penalty</dt>
-          <dd className="font-medium text-neutral-700 dark:text-neutral-100">{(shift.penaltyMinutes / 60).toFixed(2)}h</dd>
-        </div>
-        <div>
-          <dt className="text-neutral-500 dark:text-neutral-300">Total</dt>
-          <dd className="font-medium text-neutral-700 dark:text-neutral-100">
-            {((shift.baseMinutes + shift.penaltyMinutes) / 60).toFixed(2)}h
-          </dd>
-        </div>
-      </dl>
+        <dl className="col-span-2 col-start-1 row-start-2 grid grid-cols-3 gap-2 text-[11px] sm:col-span-1 sm:col-start-2 sm:row-start-1 sm:gap-4 sm:text-xs">
+          <div>
+            <dt className="text-neutral-500 dark:text-neutral-300">Base</dt>
+            <dd className="font-medium text-neutral-700 dark:text-neutral-100">{(shift.baseMinutes / 60).toFixed(2)}h</dd>
+          </div>
+          <div>
+            <dt className="text-neutral-500 dark:text-neutral-300">Penalty</dt>
+            <dd className="font-medium text-neutral-700 dark:text-neutral-100">{(shift.penaltyMinutes / 60).toFixed(2)}h</dd>
+          </div>
+          <div>
+            <dt className="text-neutral-500 dark:text-neutral-300">Total</dt>
+            <dd className="font-medium text-neutral-700 dark:text-neutral-100">
+              {((shift.baseMinutes + shift.penaltyMinutes) / 60).toFixed(2)}h
+            </dd>
+          </div>
+        </dl>
+      </div>
       {(onEdit || onDelete) && (
         <footer className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
           {onEdit && (


### PR DESCRIPTION
## Summary
- rework the shift card layout on the summary page so date/time, hours, and pay align on one line on wide screens
- ensure on narrow screens the pay stays on the first row while the hours breakdown spans the full-width second row

## Testing
- npm run lint *(fails: ESLint 9 requires eslint.config.js and the repo still uses legacy config)*

------
https://chatgpt.com/codex/tasks/task_e_68dd1214975483318e05469b3398ecee