### PR TITLE
Hide Today button on mobile shifts view

### DIFF
--- a/src/app/routes/ShiftsPage.tsx
+++ b/src/app/routes/ShiftsPage.tsx
@@ -213,7 +213,7 @@ export default function ShiftsPage() {
           <button
             type="button"
             onClick={goToToday}
-            className="rounded-full border border-neutral-200 px-3 py-1 text-sm font-medium text-neutral-600 transition hover:border-primary hover:text-primary-emphasis dark:border-midnight-700 dark:text-neutral-200"
+            className="hidden rounded-full border border-neutral-200 px-3 py-1 text-sm font-medium text-neutral-600 transition hover:border-primary hover:text-primary-emphasis dark:border-midnight-700 dark:text-neutral-200 sm:inline-flex"
           >
             Today
           </button>


### PR DESCRIPTION
## Summary
- hide the calendar "Today" quick action on the Shifts view for narrow screens where a dedicated mobile control already exists

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd190374b483318ba2b67e7459c13b