### PR TITLE
Add security response headers to Nginx deployment config

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ Unit tests focus on pay rules and schedule logic. Add Playwright tests under `sr
 
 The app uses `vite-plugin-pwa` for service worker generation. Assets in `public/` supply install icons. Run `npm run build` to generate the service worker and manifest.
 
+## Deployment
+
+The sample Nginx configuration in `deploy/nginx.conf` is tuned for static hosting and now emits the following response headers:
+
+- `Content-Security-Policy` locks scripts, styles, workers, and other active content to same-origin assets while allowing API calls to `https://date.nager.at` for the optional public-holiday lookup. If you proxy requests through a different host or rely on additional CDNs, extend the relevant directives (for example, `connect-src`).
+- `X-Content-Type-Options: nosniff` prevents MIME-type sniffing on cached resources.
+- `Referrer-Policy: no-referrer` strips outgoing referrers; tighten or relax as required by your analytics posture.
+- `Permissions-Policy` disables unused browser capabilities such as camera, microphone, geolocation, and USB access. Remove specific directives only if a custom fork needs those APIs.
+- `Strict-Transport-Security` is preconfigured with a one-year TTL. Browsers only honor it on HTTPS responses, so leave it enabled when Chrona is served over TLS and disable it if you terminate TLS elsewhere and prefer to manage HSTS upstream.
+
+Because each cache-specific `location` block overrides inherited headers, the configuration duplicates the security directives to cover `/assets/`, `/sw.js`, and the SPA fallback. If you add more locations, remember to include the same header set.
+
 ## Project structure
 
 The project follows the guidance from `AGENTS.md`. Core directories include:

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -4,6 +4,10 @@ server {
   root /usr/share/nginx/html;
   index index.html;
 
+  # Content Security Policy limits requests to same-origin assets, plus the
+  # public holiday API used for optional enrichments.
+  set $csp "default-src 'self'; script-src 'self'; style-src 'self'; connect-src 'self' https://date.nager.at; img-src 'self' data:; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; worker-src 'self'; manifest-src 'self'";
+
   # Gzip for common types
   gzip on;
   gzip_comp_level 5;
@@ -19,24 +23,52 @@ server {
 
   # Hashed static assets: long-lived & immutable
   location /assets/ {
+    # Security headers
+    add_header Content-Security-Policy $csp always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "no-referrer" always;
+    add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), display-capture=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), usb=()" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+
     add_header Cache-Control "public, max-age=31536000, immutable";
     try_files $uri =404;
   }
 
   # Service worker: always revalidate
   location = /sw.js {
+    # Security headers
+    add_header Content-Security-Policy $csp always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "no-referrer" always;
+    add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), display-capture=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), usb=()" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+
     add_header Cache-Control "public, max-age=0, must-revalidate";
     try_files $uri =404;
   }
 
   # Icons, manifest, images: 7 days
   location ~* \.(png|jpe?g|gif|webp|ico|svg|json)$ {
+    # Security headers
+    add_header Content-Security-Policy $csp always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "no-referrer" always;
+    add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), display-capture=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), usb=()" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+
     add_header Cache-Control "public, max-age=604800";
     try_files $uri =404;
   }
 
   # SPA fallback: everything else
   location / {
+    # Security headers
+    add_header Content-Security-Policy $csp always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "no-referrer" always;
+    add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), display-capture=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), usb=()" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+
     # Do not aggressively cache index.html (ensures new SW/HTML picked up)
     add_header Cache-Control "no-store";
     try_files $uri /index.html;


### PR DESCRIPTION
## Summary
- add CSP, referrer policy, permissions policy, HSTS, and other security headers to every nginx location
- document the new headers and guidance for adjusting CSP allowances in the deployment section of the README

## Testing
- not run (configuration and docs only)


------
https://chatgpt.com/codex/tasks/task_e_68de4400c5b8833193bc49004909df16