### PR TITLE
Normalize CSV parser shift timestamps to UTC

### DIFF
--- a/src/app/logic/csv.ts
+++ b/src/app/logic/csv.ts
@@ -1,4 +1,4 @@
-import { addDays, format, formatISO, isValid, parse } from 'date-fns';
+import { format, isValid, parse } from 'date-fns';
 import templateCsvContent from '../assets/shift-import-template.csv?raw';
 import type { Shift } from '../db/schema';
 
@@ -194,20 +194,25 @@ export function parseShiftsCsv(content: string): {
       continue;
     }
 
-    const startDate = new Date(parsedDate);
-    startDate.setHours(startTime.hours, startTime.minutes, 0, 0);
+    const year = parsedDate.getFullYear();
+    const month = parsedDate.getMonth();
+    const day = parsedDate.getDate();
 
-    let endDate = new Date(parsedDate);
-    endDate.setHours(finishTime.hours, finishTime.minutes, 0, 0);
+    const startDate = new Date(Date.UTC(year, month, day, startTime.hours, startTime.minutes, 0, 0));
+
+    let endDate = new Date(Date.UTC(year, month, day, finishTime.hours, finishTime.minutes, 0, 0));
 
     if (endDate <= startDate) {
-      endDate = addDays(endDate, 1);
+      endDate = new Date(Date.UTC(year, month, day + 1, finishTime.hours, finishTime.minutes, 0, 0));
     }
+
+    const startISO = startDate.toISOString().replace(/\.\d{3}Z$/, 'Z');
+    const endISO = endDate.toISOString().replace(/\.\d{3}Z$/, 'Z');
 
     entries.push({
       line: lineNumber,
-      startISO: formatISO(startDate),
-      endISO: formatISO(endDate),
+      startISO,
+      endISO,
       note: note || undefined
     });
   }


### PR DESCRIPTION
## Summary
- ensure CSV shift import timestamps are built via UTC-aware components
- keep overnight adjustments while emitting canonical Z-terminated ISO strings

## Testing
- pnpm test src/tests/logic/csv.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68de444f1bd08331a97fccab8a6cd3d0