### PR TITLE
Add size guardrails to backup restore flow

### DIFF
--- a/src/app/components/BackupRestorePanel.tsx
+++ b/src/app/components/BackupRestorePanel.tsx
@@ -121,11 +121,7 @@ export default function BackupRestorePanel() {
     setInfoMessage(null);
 
     try {
-      const buffer = await selectedFile.arrayBuffer();
-      const hydratedFile = new File([buffer], selectedFile.name, {
-        type: selectedFile.type,
-      });
-      const result = await restoreBackupArchive(hydratedFile, new Date());
+      const result = await restoreBackupArchive(selectedFile, new Date());
       appendLogs(result.logs);
       await reloadSettings();
       setInfoMessage('Backup restored successfully.');


### PR DESCRIPTION
## Summary
- add size limits to backup restoration, including pre-read validation and decompressed size checks
- surface clearer restore errors and avoid eagerly reading the selected archive in the UI
- cover oversized and inflated archive cases alongside existing backup tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de43eb1cfc8331b925ad99b06c208c