### PR TITLE
Fix CSV export timezone determinism

### DIFF
--- a/src/app/logic/csv.ts
+++ b/src/app/logic/csv.ts
@@ -1,4 +1,4 @@
-import { addDays, format, formatISO, isValid, parse } from 'date-fns';
+import { addDays, formatISO, isValid, parse } from 'date-fns';
 import templateCsvContent from '../assets/shift-import-template.csv?raw';
 import type { Shift } from '../db/schema';
 
@@ -93,10 +93,15 @@ export function shiftsToCsv(shifts: Shift[]): string {
   shifts.forEach((shift) => {
     const startDate = new Date(shift.startISO);
     const endDate = shift.endISO ? new Date(shift.endISO) : null;
+    const startIsoString = Number.isNaN(startDate.getTime()) ? null : startDate.toISOString();
+    const endIsoString = endDate && !Number.isNaN(endDate.getTime()) ? endDate.toISOString() : null;
+    const startDatePart = startIsoString ? startIsoString.slice(0, 10) : '';
+    const startTimePart = startIsoString ? startIsoString.slice(11, 16) : '';
+    const endTimePart = endIsoString ? endIsoString.slice(11, 16) : '';
     const cells = [
-      format(startDate, 'yyyy-MM-dd'),
-      format(startDate, 'HH:mm'),
-      endDate ? format(endDate, 'HH:mm') : '',
+      startDatePart,
+      startTimePart,
+      endTimePart,
       shift.note?.trim() ?? ''
     ];
     lines.push(cells.map(escapeCsvValue).join(','));

--- a/src/tests/logic/csv.test.ts
+++ b/src/tests/logic/csv.test.ts
@@ -38,6 +38,31 @@ describe('shiftsToCsv', () => {
 
     expect(csv).toBe('date,start,finish,notes\n2024-01-02,07:15,15:45,"Includes, comma"');
   });
+
+  it('serializes consistently across timezone environments', () => {
+    const shift = createShift({
+      note: 'Timezone check',
+      startISO: '2024-01-02T07:15:00.000Z',
+      endISO: '2024-01-02T15:45:00.000Z'
+    });
+
+    const expected = 'date,start,finish,notes\n2024-01-02,07:15,15:45,Timezone check';
+    const originalTz = process.env.TZ;
+    const timezones = ['UTC', 'America/New_York', 'Asia/Tokyo'];
+
+    try {
+      for (const timezone of timezones) {
+        process.env.TZ = timezone;
+        expect(shiftsToCsv([shift])).toBe(expected);
+      }
+    } finally {
+      if (originalTz === undefined) {
+        delete process.env.TZ;
+      } else {
+        process.env.TZ = originalTz;
+      }
+    }
+  });
 });
 
 describe('parseShiftsCsv', () => {


### PR DESCRIPTION
## Summary
- derive CSV export date and time fields from ISO strings to avoid timezone-dependent formatting
- add a regression test ensuring CSV export stays consistent when the runtime timezone changes

## Testing
- pnpm test src/tests/logic/csv.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68de443d4274833188af47a3bb4ca115