### PR TITLE
Fix Playwright IndexedDB reset for smoke tests

### DIFF
--- a/src/tests/e2e/smoke.spec.ts
+++ b/src/tests/e2e/smoke.spec.ts
@@ -4,9 +4,10 @@ const APP_TITLE = /Chrona/i;
 const HOLIDAY_API_PATTERN = 'https://date.nager.at/api/v3/*';
 
 test.describe('Chrona PWA UI', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('about:blank');
-    await page.evaluate(async () => {
+  test.beforeEach(async ({ page, context }) => {
+    const storagePage = await context.newPage();
+    await storagePage.goto('/');
+    await storagePage.evaluate(async () => {
       await new Promise<void>((resolve, reject) => {
         const request = indexedDB.deleteDatabase('shift-recorder');
         request.onsuccess = () => resolve();
@@ -16,6 +17,7 @@ test.describe('Chrona PWA UI', () => {
       localStorage.clear();
       sessionStorage.clear();
     });
+    await storagePage.close();
 
     await page.route(HOLIDAY_API_PATTERN, async (route) => {
       const url = route.request().url();


### PR DESCRIPTION
## Summary
- run IndexedDB cleanup from a same-origin helper page before each test
- ensure storage is cleared and helper page closed prior to navigation

## Testing
- npx playwright test src/tests/e2e/smoke.spec.ts *(fails: host system missing browser dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68de4aea566883318595af29ab13c495