### PR TITLE
Add VS Code Playwright run configuration without inspector pause

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,6 +25,22 @@
       }
     },
     {
+      "name": "Playwright Tests",
+      "type": "pwa-node",
+      "request": "launch",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": [
+        "playwright",
+        "test"
+      ],
+      "env": {
+        "PWDEBUG": "0",
+        "TZ": "Australia/Brisbane"
+      },
+      "console": "integratedTerminal",
+      "cwd": "${workspaceFolder}"
+    },
+    {
       "name": "Playwright Tests (Debug)",
       "type": "pwa-node",
       "request": "launch",


### PR DESCRIPTION
## Summary
- add a dedicated VS Code launch profile to run Playwright tests without opening the Inspector
- keep the existing debug configuration for cases where step-by-step debugging is desired

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68de4abf05988331991e7fa52c604d6e