### PR TITLE
Fix today halo persisting after date selection

### DIFF
--- a/src/app/routes/ShiftsPage.tsx
+++ b/src/app/routes/ShiftsPage.tsx
@@ -244,7 +244,8 @@ export default function ShiftsPage() {
 
                   const shouldHighlightSelection =
                     isSelected && (hasUserInteracted || hasShifts || isCurrentDay);
-                  const shouldHighlightToday = !shouldHighlightSelection && isCurrentDay && hasShifts;
+                  const shouldHighlightToday =
+                    !hasUserInteracted && !shouldHighlightSelection && isCurrentDay && hasShifts;
 
                   const dayNumberClasses = [
                     'flex h-8 w-8 items-center justify-center rounded-full text-sm font-semibold transition',


### PR DESCRIPTION
## Summary
- ensure the shifts calendar only highlights today on initial load so the halo follows the selected day afterwards

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de4dbf7ac48331abff97024b79eba5