### PR TITLE
Adjust Playwright selectors for updated settings and import copy

### DIFF
--- a/src/tests/e2e/smoke.spec.ts
+++ b/src/tests/e2e/smoke.spec.ts
@@ -142,7 +142,7 @@ test.describe('Chrona PWA UI', () => {
     await expect(page.getByText('Penalty hours (daily window)')).toBeVisible();
     await expect(page.getByText('Enable a daily penalty window')).toBeVisible();
     await expect(page.getByText('Penalty applies all day on')).toBeVisible();
-    await expect(page.getByText('Public holidays')).toBeVisible();
+    await expect(page.locator('legend', { hasText: 'Public holidays' })).toBeVisible();
     await expect(page.getByText('Holiday region')).toBeVisible();
     await expect(page.getByText('State or region')).toBeVisible();
     await expect(page.getByText('Holiday dates are sourced from')).toBeVisible();
@@ -263,7 +263,7 @@ test.describe('Chrona PWA UI', () => {
     });
 
     await expect(page.getByRole('heading', { name: 'Import results' })).toBeVisible();
-    await expect(page.getByText('Imported 1 of 1 rows.')).toBeVisible();
+    await expect(page.getByText('Imported 1 of 1 row.')).toBeVisible();
     await expect(page.getByText('Imported successfully')).toBeVisible();
 
     await page.getByRole('button', { name: 'Backup & restore' }).click();


### PR DESCRIPTION
## Summary
- refine the settings penalty rules tab assertion to target the legend element and avoid strict-mode conflicts
- update the import results expectation to match the singular-row copy shown in the UI

## Testing
- npx playwright test *(fails: host system missing browser dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68de51cd6ecc833183459b9e8cfa3607