### PR TITLE
Highlight today's date on desktop shifts calendar

### DIFF
--- a/src/app/routes/ShiftsPage.tsx
+++ b/src/app/routes/ShiftsPage.tsx
@@ -264,6 +264,9 @@ export default function ShiftsPage() {
                       : 'text-neutral-400 dark:text-neutral-500',
                     hasShifts
                       ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-500/20 dark:text-emerald-100'
+                      : null,
+                    isCurrentDay
+                      ? 'sm:ring-2 sm:ring-purple-400 sm:ring-offset-2 sm:ring-offset-white dark:sm:ring-purple-500/70 dark:sm:ring-offset-midnight-950'
                       : null
                   ]
                     .filter(Boolean)


### PR DESCRIPTION
## Summary
- add a purple ring indicator around today's date on the desktop calendar view of the Shifts page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de5500f7648331b5bd41f5f7b20c1a