### PR TITLE
Relax import success check in Playwright smoke test

### DIFF
--- a/src/tests/e2e/smoke.spec.ts
+++ b/src/tests/e2e/smoke.spec.ts
@@ -303,7 +303,7 @@ test.describe('Chrona PWA UI', () => {
       .first()
       .locator('..');
 
-    await expect(importResultsSection.getByText('Imported successfully')).toBeVisible();
+    await expect(importResultsSection.getByRole('status')).toContainText('Imported successfully');
     await expect(importedStat.locator('span').nth(1)).toHaveText('1');
     await expect(duplicateStat.locator('span').nth(1)).toHaveText('0');
     await expect(overlapStat.locator('span').nth(1)).toHaveText('0');


### PR DESCRIPTION
## Summary
- update the smoke test import assertion to target the status banner rather than text matching

## Testing
- npx playwright test --project=chromium --grep "user can manage shifts" *(fails: missing system deps for browser launch)*

------
https://chatgpt.com/codex/tasks/task_e_68de627c90c883319927272988f726f5