### PR TITLE
Fix CSV import to use local timezone parsing

### DIFF
--- a/src/app/logic/csv.ts
+++ b/src/app/logic/csv.ts
@@ -234,16 +234,13 @@ export function parseShiftsCsv(content: string): {
       continue;
     }
 
-    const year = parsedDate.getFullYear();
-    const month = parsedDate.getMonth();
-    const day = parsedDate.getDate();
+    const startDate = new Date(parsedDate.getTime());
+    startDate.setHours(startTime.hours, startTime.minutes, 0, 0);
 
-    const startDate = new Date(Date.UTC(year, month, day, startTime.hours, startTime.minutes, 0, 0));
-
-    let endDate = new Date(Date.UTC(year, month, day, finishTime.hours, finishTime.minutes, 0, 0));
-
+    const endDate = new Date(parsedDate.getTime());
+    endDate.setHours(finishTime.hours, finishTime.minutes, 0, 0);
     if (endDate <= startDate) {
-      endDate = new Date(Date.UTC(year, month, day + 1, finishTime.hours, finishTime.minutes, 0, 0));
+      endDate.setDate(endDate.getDate() + 1);
     }
 
     const startISO = startDate.toISOString().replace(/\.\d{3}Z$/, 'Z');


### PR DESCRIPTION
## Summary
- adjust CSV parsing to construct shift timestamps in the user's local timezone instead of UTC
- ensure overnight shifts roll to the next day without altering the recorded start time

## Testing
- `npx playwright test` *(fails: missing system dependencies for Chromium in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68de65999a988331861704b79fe8b57e