### PR TITLE
Fix CSV parsing to produce timezone-independent ISO dates

### DIFF
--- a/src/app/logic/csv.ts
+++ b/src/app/logic/csv.ts
@@ -234,13 +234,15 @@ export function parseShiftsCsv(content: string): {
       continue;
     }
 
-    const startDate = new Date(parsedDate.getTime());
-    startDate.setHours(startTime.hours, startTime.minutes, 0, 0);
+    const startDate = new Date(
+      Date.UTC(parsedDate.getFullYear(), parsedDate.getMonth(), parsedDate.getDate(), startTime.hours, startTime.minutes, 0, 0)
+    );
 
-    const endDate = new Date(parsedDate.getTime());
-    endDate.setHours(finishTime.hours, finishTime.minutes, 0, 0);
+    const endDate = new Date(
+      Date.UTC(parsedDate.getFullYear(), parsedDate.getMonth(), parsedDate.getDate(), finishTime.hours, finishTime.minutes, 0, 0)
+    );
     if (endDate <= startDate) {
-      endDate.setDate(endDate.getDate() + 1);
+      endDate.setUTCDate(endDate.getUTCDate() + 1);
     }
 
     const startISO = startDate.toISOString().replace(/\.\d{3}Z$/, 'Z');


### PR DESCRIPTION
## Summary
- construct parsed CSV shift start and end dates using UTC to avoid timezone offsets
- preserve overnight handling by incrementing the UTC day when the finish time precedes the start

## Testing
- npm test -- --run src/tests/logic/csv.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68de66c97ea083318dafcb470c2cc87c