### PR TITLE
Implement service worker driven shift notifications

### DIFF
--- a/src/app/notifications/constants.ts
+++ b/src/app/notifications/constants.ts
@@ -1,0 +1,2 @@
+export const PERIODIC_SYNC_TAG = 'shift-recorder-shift-reminders';
+export const NOTIFICATION_TRIGGER_MESSAGE = 'trigger-notifications';

--- a/src/app/notifications/scheduling.ts
+++ b/src/app/notifications/scheduling.ts
@@ -1,0 +1,72 @@
+import { formatDistanceStrict } from 'date-fns';
+import type { NotificationSchedule, Settings } from '../db/schema';
+
+type NotificationScheduleStore = {
+  notificationSchedules: {
+    put(schedule: NotificationSchedule): Promise<string>;
+    delete(id: string): Promise<void>;
+  };
+};
+
+function formatShiftTime(date: Date, use24HourTime: boolean): string {
+  return new Intl.DateTimeFormat(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: !use24HourTime,
+    hourCycle: use24HourTime ? 'h23' : 'h12'
+  }).format(date);
+}
+
+export function buildNotificationDetails(
+  schedule: NotificationSchedule,
+  settings: Settings,
+  now: Date
+): { title: string; body: string; requireInteraction: boolean } {
+  const shiftStart = new Date(schedule.shiftStartISO);
+  const timeLabel = formatShiftTime(shiftStart, settings.use24HourTime);
+
+  if (schedule.type === 'long-range') {
+    const lead = formatDistanceStrict(now, shiftStart, { unit: 'minute' });
+    return {
+      title: 'Upcoming shift reminder',
+      body: `Shift at ${timeLabel} starts in ${lead}.`,
+      requireInteraction: false
+    };
+  }
+
+  const remaining = formatDistanceStrict(now, shiftStart, { unit: 'minute' });
+  return {
+    title: 'Shift starting soon',
+    body: `Shift at ${timeLabel} begins in ${remaining}. Tap when you're ready to clock in.`,
+    requireInteraction: true
+  };
+}
+
+export async function advanceSchedule(
+  store: NotificationScheduleStore,
+  schedule: NotificationSchedule,
+  triggeredAt: Date
+): Promise<void> {
+  const nowISO = triggeredAt.toISOString();
+  if (schedule.repeatIntervalMinutes && schedule.repeatIntervalMinutes > 0) {
+    const repeatMs = schedule.repeatIntervalMinutes * 60_000;
+    const limit = new Date(schedule.validUntilISO).getTime();
+    let nextTime = new Date(schedule.nextTriggerISO).getTime();
+
+    while (nextTime <= triggeredAt.getTime()) {
+      nextTime += repeatMs;
+    }
+
+    if (nextTime < limit) {
+      await store.notificationSchedules.put({
+        ...schedule,
+        nextTriggerISO: new Date(nextTime).toISOString(),
+        lastTriggeredISO: nowISO,
+        updatedAt: nowISO
+      });
+      return;
+    }
+  }
+
+  await store.notificationSchedules.delete(schedule.id);
+}

--- a/src/app/state/NotificationManager.tsx
+++ b/src/app/state/NotificationManager.tsx
@@ -1,166 +1,157 @@
-import { useEffect, useRef } from 'react';
-import { formatDistanceStrict } from 'date-fns';
-import { db, type NotificationSchedule, type Settings } from '../db/schema';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSettings } from './SettingsContext';
+import { NOTIFICATION_TRIGGER_MESSAGE, PERIODIC_SYNC_TAG } from '../notifications/constants';
 
-const CHECK_INTERVAL_MS = 60_000;
-
-function formatShiftTime(date: Date, use24HourTime: boolean): string {
-  return new Intl.DateTimeFormat(undefined, {
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: !use24HourTime,
-    hourCycle: use24HourTime ? 'h23' : 'h12'
-  }).format(date);
-}
-
-function buildNotificationDetails(
-  schedule: NotificationSchedule,
-  settings: Settings,
-  now: Date
-): { title: string; body: string; requireInteraction: boolean } {
-  const shiftStart = new Date(schedule.shiftStartISO);
-  const timeLabel = formatShiftTime(shiftStart, settings.use24HourTime);
-
-  if (schedule.type === 'long-range') {
-    const lead = formatDistanceStrict(now, shiftStart, { unit: 'minute' });
-    return {
-      title: 'Upcoming shift reminder',
-      body: `Shift at ${timeLabel} starts in ${lead}.`,
-      requireInteraction: false
-    };
-  }
-
-  const remaining = formatDistanceStrict(now, shiftStart, { unit: 'minute' });
-  return {
-    title: 'Shift starting soon',
-    body: `Shift at ${timeLabel} begins in ${remaining}. Tap when you\'re ready to clock in.`,
-    requireInteraction: true
+type PeriodicSyncRegistration = ServiceWorkerRegistration & {
+  periodicSync?: {
+    getTags(): Promise<string[]>;
+    register(tag: string, options: { minInterval: number }): Promise<void>;
   };
-}
-
-async function advanceSchedule(schedule: NotificationSchedule, triggeredAt: Date): Promise<void> {
-  const nowISO = triggeredAt.toISOString();
-  if (schedule.repeatIntervalMinutes && schedule.repeatIntervalMinutes > 0) {
-    const repeatMs = schedule.repeatIntervalMinutes * 60_000;
-    const limit = new Date(schedule.validUntilISO).getTime();
-    let nextTime = new Date(schedule.nextTriggerISO).getTime();
-
-    while (nextTime <= triggeredAt.getTime()) {
-      nextTime += repeatMs;
-    }
-
-    if (nextTime < limit) {
-      await db.notificationSchedules.put({
-        ...schedule,
-        nextTriggerISO: new Date(nextTime).toISOString(),
-        lastTriggeredISO: nowISO,
-        updatedAt: nowISO
-      });
-      return;
-    }
-  }
-
-  await db.notificationSchedules.delete(schedule.id);
-}
+};
 
 export default function NotificationManager() {
   const { settings } = useSettings();
   const hasRequestedPermission = useRef(false);
+  const [permissionState, setPermissionState] = useState<NotificationPermission>(() => {
+    if (typeof window === 'undefined' || typeof Notification === 'undefined') {
+      return 'default';
+    }
+    return Notification.permission;
+  });
 
-  useEffect(() => {
-    if (typeof window === 'undefined' || typeof navigator === 'undefined') {
-      return;
-    }
+  const minIntervalMinutes = useMemo(() => {
     if (!settings) {
-      return;
+      return 15;
     }
-    if (!('Notification' in window)) {
-      return;
+    const { notificationRepeatMinutes } = settings;
+    if (notificationRepeatMinutes && notificationRepeatMinutes >= 5) {
+      return notificationRepeatMinutes;
     }
-    if (hasRequestedPermission.current) {
-      return;
-    }
-    if (Notification.permission === 'default') {
-      hasRequestedPermission.current = true;
-      void Notification.requestPermission().catch(() => {
-        // Ignore permission request errors; user may have dismissed the prompt.
-      });
-      return;
-    }
-    hasRequestedPermission.current = true;
+    return 5;
   }, [settings]);
 
   useEffect(() => {
     if (typeof window === 'undefined' || typeof navigator === 'undefined') {
       return;
     }
+    if (!('permissions' in navigator)) {
+      return;
+    }
+
+    let permissionStatus: PermissionStatus | null = null;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const status = await navigator.permissions.query({
+          name: 'notifications' as PermissionName
+        });
+        if (cancelled) {
+          return;
+        }
+        permissionStatus = status;
+        const mapState = (state: PermissionState): NotificationPermission => {
+          if (state === 'prompt') {
+            return 'default';
+          }
+          return state as NotificationPermission;
+        };
+        setPermissionState(mapState(status.state));
+        status.onchange = () => {
+          setPermissionState(mapState(status.state));
+        };
+      } catch (error) {
+        console.warn('Unable to subscribe to notification permission changes', error);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (permissionStatus) {
+        permissionStatus.onchange = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+      return;
+    }
     if (!settings) {
       return;
     }
-    if (!('Notification' in window)) {
+    if (typeof Notification === 'undefined') {
+      return;
+    }
+    if (permissionState !== 'default') {
+      hasRequestedPermission.current = true;
+      return;
+    }
+    if (hasRequestedPermission.current) {
+      return;
+    }
+
+    hasRequestedPermission.current = true;
+    Notification.requestPermission()
+      .then((result) => {
+        setPermissionState(result);
+      })
+      .catch(() => {
+        setPermissionState(Notification.permission);
+      });
+  }, [settings, permissionState]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+      return;
+    }
+    if (!settings) {
+      return;
+    }
+    if (typeof Notification === 'undefined' || permissionState !== 'granted') {
       return;
     }
     if (!('serviceWorker' in navigator)) {
       return;
     }
 
-    let intervalId: number | undefined;
-    let isProcessing = false;
+    let cancelled = false;
 
-    const processNotifications = async () => {
-      if (isProcessing) {
-        return;
-      }
-      if (Notification.permission !== 'granted') {
-        return;
-      }
-      isProcessing = true;
+    const registerBackgroundTasks = async () => {
       try {
-        const now = new Date();
-        const nowISO = now.toISOString();
-        const due = await db.notificationSchedules
-          .where('nextTriggerISO')
-          .belowOrEqual(nowISO)
-          .toArray();
-
-        if (due.length === 0) {
+        const registration = (await navigator.serviceWorker.ready) as PeriodicSyncRegistration;
+        if (cancelled) {
           return;
         }
 
-        const registration = await navigator.serviceWorker.ready;
-
-        for (const schedule of due) {
-          const details = buildNotificationDetails(schedule, settings, now);
+        const periodicSync = registration.periodicSync;
+        if (periodicSync) {
           try {
-            await registration.showNotification(details.title, {
-              body: details.body,
-              tag: schedule.id,
-              requireInteraction: details.requireInteraction,
-              data: {
-                shiftId: schedule.shiftId,
-                type: schedule.type
-              }
-            });
+            const tags = (await periodicSync.getTags?.()) ?? [];
+            if (!tags.includes(PERIODIC_SYNC_TAG)) {
+              await periodicSync.register(PERIODIC_SYNC_TAG, {
+                minInterval: minIntervalMinutes * 60_000
+              });
+            }
           } catch (error) {
-            console.error('Failed to show notification', error);
+            console.warn('Unable to register periodic background sync', error);
           }
-          await advanceSchedule(schedule, now);
         }
-      } finally {
-        isProcessing = false;
+
+        if (registration.active?.postMessage) {
+          registration.active.postMessage({ type: NOTIFICATION_TRIGGER_MESSAGE });
+        }
+      } catch (error) {
+        console.warn('Notification background task registration failed', error);
       }
     };
 
-    void processNotifications();
-    intervalId = window.setInterval(processNotifications, CHECK_INTERVAL_MS);
+    void registerBackgroundTasks();
 
     return () => {
-      if (intervalId) {
-        window.clearInterval(intervalId);
-      }
+      cancelled = true;
     };
-  }, [settings]);
+  }, [settings, minIntervalMinutes, permissionState]);
 
   return null;
 }

--- a/src/sw-notifications.ts
+++ b/src/sw-notifications.ts
@@ -1,0 +1,93 @@
+/// <reference lib="webworker" />
+import { db, DEFAULT_SETTINGS, type NotificationSchedule, type Settings } from './app/db/schema';
+import { buildNotificationDetails, advanceSchedule } from './app/notifications/scheduling';
+import { NOTIFICATION_TRIGGER_MESSAGE, PERIODIC_SYNC_TAG } from './app/notifications/constants';
+
+declare const self: ServiceWorkerGlobalScope;
+
+type NotificationTriggerReason = 'periodic-sync' | 'push' | 'message' | 'notificationclick';
+type PeriodicSyncEventLike = ExtendableEvent & { tag?: string };
+
+async function loadSettings(): Promise<Settings> {
+  const settings = await db.settings.get('singleton');
+  return settings ?? DEFAULT_SETTINGS;
+}
+
+async function loadDueSchedules(now: Date): Promise<NotificationSchedule[]> {
+  const nowISO = now.toISOString();
+  return db.notificationSchedules.where('nextTriggerISO').belowOrEqual(nowISO).toArray();
+}
+
+async function dispatchNotifications(reason: NotificationTriggerReason): Promise<void> {
+  if (typeof Notification === 'undefined' || Notification.permission !== 'granted') {
+    return;
+  }
+
+  const now = new Date();
+  const [settings, schedules] = await Promise.all([loadSettings(), loadDueSchedules(now)]);
+
+  if (schedules.length === 0) {
+    return;
+  }
+
+  for (const schedule of schedules) {
+    try {
+      const details = buildNotificationDetails(schedule, settings, now);
+      await self.registration.showNotification(details.title, {
+        body: details.body,
+        tag: schedule.id,
+        requireInteraction: details.requireInteraction,
+        data: {
+          shiftId: schedule.shiftId,
+          type: schedule.type,
+          reason
+        }
+      });
+    } catch (error) {
+      console.error('Failed to display shift reminder notification', error);
+    } finally {
+      await advanceSchedule(db, schedule, now);
+    }
+  }
+}
+
+self.addEventListener('periodicsync', (event) => {
+  const syncEvent = event as PeriodicSyncEventLike;
+  if (syncEvent.tag !== PERIODIC_SYNC_TAG) {
+    return;
+  }
+  syncEvent.waitUntil(dispatchNotifications('periodic-sync'));
+});
+
+self.addEventListener('push', (event) => {
+  (event as ExtendableEvent).waitUntil(dispatchNotifications('push'));
+});
+
+self.addEventListener('message', (event) => {
+  const messageEvent = event as ExtendableMessageEvent;
+  if (!messageEvent.data || messageEvent.data.type !== NOTIFICATION_TRIGGER_MESSAGE) {
+    return;
+  }
+  messageEvent.waitUntil(dispatchNotifications('message'));
+});
+
+self.addEventListener('notificationclick', (event) => {
+  const notificationEvent = event as NotificationEvent;
+  notificationEvent.notification.close();
+  notificationEvent.waitUntil(
+    (async () => {
+      const windowClients = await self.clients.matchAll({
+        type: 'window',
+        includeUncontrolled: true
+      });
+      if (windowClients.length > 0) {
+        await windowClients[0].focus();
+      } else {
+        await self.clients.openWindow(self.registration.scope);
+      }
+      await dispatchNotifications('notificationclick');
+    })()
+  );
+});
+
+export {};

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,0 +1,13 @@
+/// <reference lib="webworker" />
+import { cleanupOutdatedCaches, precacheAndRoute } from 'workbox-precaching';
+import { clientsClaim } from 'workbox-core';
+import './sw-notifications';
+
+declare const self: ServiceWorkerGlobalScope & { __WB_MANIFEST: any };
+
+self.skipWaiting();
+clientsClaim();
+cleanupOutdatedCaches();
+precacheAndRoute(self.__WB_MANIFEST);
+
+export {};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,9 +8,11 @@ export default defineConfig({
     VitePWA({
       registerType: 'autoUpdate',
       includeAssets: ['favicon.svg', 'favicon.ico', 'robots.txt', 'apple-touch-icon.svg'],
-      workbox: {
-        clientsClaim: true,
-        skipWaiting: true,
+      strategies: 'injectManifest',
+      srcDir: 'src',
+      filename: 'sw.ts',
+      injectManifest: {
+        globPatterns: ['**/*.{js,css,html,ico,png,svg,json,webmanifest}']
       },
       manifest: {
         name: 'Chrona',


### PR DESCRIPTION
## Summary
- add a dedicated service worker bundle that reads scheduled reminders from IndexedDB during periodic sync, push, and click events
- share notification scheduling helpers with the worker and simplify the NotificationManager to only handle permission and registration
- switch the PWA build to an inject-manifest workflow to include the new service worker module

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dee00ffed88331ba256b77292c0fd8