### PR TITLE
Fix Vite alias resolution for @tax-engine package

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,15 @@
 import { configDefaults, defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const projectRootDir = fileURLToPath(new URL('.', import.meta.url));
+const resolveFromRoot = (relativePath: string) =>
+  path.resolve(projectRootDir, relativePath);
+const toPosixPath = (p: string) => p.replace(/\\/g, '/');
+const taxEngineFsRoot = resolveFromRoot('packages/tax-engine/src');
+const taxEngineRoot = toPosixPath(taxEngineFsRoot);
 
 export default defineConfig({
   plugins: [
@@ -44,11 +53,21 @@ export default defineConfig({
     })
   ],
   resolve: {
-    alias: {
-      '@app': '/src/app',
-      '@tax-engine': '/packages/tax-engine/src',
-      '@tax-engine/core': '/packages/tax-engine/src/core/index.ts'
-    }
+    alias: [
+      { find: '@app', replacement: resolveFromRoot('src/app') },
+      {
+        find: '@tax-engine/core',
+        replacement: toPosixPath(path.resolve(taxEngineFsRoot, 'core/index.ts'))
+      },
+      {
+        find: '@tax-engine',
+        replacement: toPosixPath(path.resolve(taxEngineFsRoot, 'core/index.ts'))
+      },
+      {
+        find: /^@tax-engine\/(.+)$/,
+        replacement: `${taxEngineRoot}/$1`
+      }
+    ]
   },
   test: {
     environment: 'happy-dom',


### PR DESCRIPTION
## Summary
- switch Vite to explicit alias entries so @tax-engine/core resolves before the package root mapping
- normalize tax engine alias paths to POSIX strings for consistent cross-platform resolution

## Testing
- npm run typecheck
- npx vite build

------
https://chatgpt.com/codex/tasks/task_e_68dee6931dec833193850a8f5d0e0e2d