### PR TITLE
Fix Vite alias for tax engine core import

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -55,6 +55,7 @@ export default defineConfig({
   resolve: {
     alias: [
       { find: '@app', replacement: resolveFromRoot('src/app') },
+      { find: '@tax-engine/core', replacement: `${taxEngineRoot}/core/index.ts` },
       { find: '@tax-engine', replacement: taxEngineRoot },
       { find: /^@tax-engine\/(.+)$/, replacement: `${taxEngineRoot}/$1` }
     ]


### PR DESCRIPTION
## Summary
- ensure the Vite alias resolves `@tax-engine/core` directly to the core index entry point

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68deebf1ee008331b56d5388b3bcd6c1