### PR TITLE
Remove tax info from shifts page and update summary layout

### DIFF
--- a/src/app/components/ShiftCard.tsx
+++ b/src/app/components/ShiftCard.tsx
@@ -1,7 +1,6 @@
 import type { Shift } from '../db/schema';
 import { useTimeFormatter } from '../state/useTimeFormatter';
 import { formatMinutesDuration } from '../utils/format';
-import { useShiftWithholding } from '../features/shifts/useShiftWithholding';
 
 const dateFormatter = new Intl.DateTimeFormat(undefined, {
   weekday: 'short',
@@ -25,11 +24,10 @@ export default function ShiftCard({ shift, currency, onEdit, onDelete }: ShiftCa
     currency,
     maximumFractionDigits: 2
   });
-  const withholding = useShiftWithholding(shift);
 
   return (
-    <article className="flex flex-col gap-3 rounded-xl border border-neutral-200 bg-white p-4 shadow-sm transition hover:shadow-md dark:border-midnight-800 dark:bg-midnight-900">
-      <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-3 sm:grid-cols-[minmax(0,1fr)_auto_auto] sm:items-center">
+    <article className="flex flex-col gap-4 rounded-xl border border-neutral-200 bg-white p-4 shadow-sm transition hover:shadow-md dark:border-midnight-800 dark:bg-midnight-900">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
         <header className="min-w-0">
           <p className="text-sm font-semibold text-neutral-700 dark:text-neutral-100">
             {dateFormatter.format(startDate)}
@@ -38,48 +36,26 @@ export default function ShiftCard({ shift, currency, onEdit, onDelete }: ShiftCa
             {timeFormatter.format(startDate)} — {endDate ? timeFormatter.format(endDate) : 'In progress'}
           </p>
         </header>
-        <p className="col-start-2 row-start-1 text-right text-base font-semibold text-neutral-900 dark:text-neutral-50 sm:col-start-3 sm:row-start-1 sm:text-lg">
+        <p className="text-right text-base font-semibold text-neutral-900 dark:text-neutral-50 sm:text-lg">
           {currencyFormatter.format(shift.totalPay / 100)}
         </p>
-        <dl className="col-span-2 col-start-1 row-start-2 grid grid-cols-3 gap-2 text-[11px] sm:col-span-1 sm:col-start-2 sm:row-start-1 sm:gap-4 sm:text-xs">
-          <div>
-            <dt className="text-neutral-500 dark:text-neutral-300">Base</dt>
-            <dd className="font-medium text-neutral-700 dark:text-neutral-100">{formatMinutesDuration(shift.baseMinutes)}</dd>
-          </div>
-          <div>
-            <dt className="text-neutral-500 dark:text-neutral-300">Penalty</dt>
-            <dd className="font-medium text-neutral-700 dark:text-neutral-100">{formatMinutesDuration(shift.penaltyMinutes)}</dd>
-          </div>
-          <div>
-            <dt className="text-neutral-500 dark:text-neutral-300">Total</dt>
-            <dd className="font-medium text-neutral-700 dark:text-neutral-100">
-              {formatMinutesDuration(shift.baseMinutes + shift.penaltyMinutes)}
-            </dd>
-          </div>
-        </dl>
-        <div className="col-span-2 grid gap-1 text-[11px] text-neutral-500 dark:text-neutral-300 sm:col-span-1 sm:col-start-3 sm:row-start-1 sm:text-xs">
-          <span className="font-semibold uppercase tracking-wide text-neutral-400 dark:text-neutral-500">
-            Withholding
-          </span>
-          <div className="flex flex-col gap-1 text-neutral-600 dark:text-neutral-200">
-            <span>
-              Tax withheld:{' '}
-              {withholding
-                ? currencyFormatter.format(withholding.totalWithheldCents / 100)
-                : '—'}
-            </span>
-            <span>
-              Take-home:{' '}
-              {withholding
-                ? currencyFormatter.format(withholding.takeHomeCents / 100)
-                : '—'}
-            </span>
-            <span className="text-[10px] text-neutral-400 dark:text-neutral-500">
-              Tax profile from Settings.
-            </span>
-          </div>
-        </div>
       </div>
+      <dl className="grid grid-cols-3 gap-2 text-[11px] sm:gap-4 sm:text-xs">
+        <div>
+          <dt className="text-neutral-500 dark:text-neutral-300">Base</dt>
+          <dd className="font-medium text-neutral-700 dark:text-neutral-100">{formatMinutesDuration(shift.baseMinutes)}</dd>
+        </div>
+        <div>
+          <dt className="text-neutral-500 dark:text-neutral-300">Penalty</dt>
+          <dd className="font-medium text-neutral-700 dark:text-neutral-100">{formatMinutesDuration(shift.penaltyMinutes)}</dd>
+        </div>
+        <div>
+          <dt className="text-neutral-500 dark:text-neutral-300">Total</dt>
+          <dd className="font-medium text-neutral-700 dark:text-neutral-100">
+            {formatMinutesDuration(shift.baseMinutes + shift.penaltyMinutes)}
+          </dd>
+        </div>
+      </dl>
       {(onEdit || onDelete) && (
         <footer className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
           {onEdit && (

--- a/src/app/routes/SummaryPage.tsx
+++ b/src/app/routes/SummaryPage.tsx
@@ -81,39 +81,46 @@ export default function SummaryPage() {
   const totalPay = totals.basePay + totals.penaltyPay;
   const totalWithheld = totals.taxWithheld;
   const totalTakeHome = totals.takeHome || totalPay;
+  const hasWithholding = totalWithheld > 0;
+  const metricCardClass =
+    'rounded-xl border border-neutral-200 bg-white p-4 shadow-sm dark:border-midnight-800 dark:bg-midnight-900 sm:p-5';
+  const metricLabelClass = 'text-[10px] uppercase tracking-wide text-neutral-500 sm:text-xs';
+  const metricDetailClass = 'text-[11px] text-neutral-500 dark:text-neutral-300 sm:text-xs';
 
   return (
     <section className="flex flex-col gap-6">
       <WeekNavigator range={range} onPrev={goPrev} onNext={goNext} />
-      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 sm:gap-4 lg:grid-cols-5">
-        <div className="rounded-xl border border-neutral-200 bg-white p-4 shadow-sm dark:border-midnight-800 dark:bg-midnight-900 sm:p-5">
-          <p className="text-[10px] uppercase tracking-wide text-neutral-500 sm:text-xs">Base hours</p>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4 xl:grid-cols-4">
+        <div className={metricCardClass}>
+          <p className={metricLabelClass}>Base hours</p>
           <p className="text-xl font-semibold leading-tight text-neutral-900 dark:text-neutral-50 sm:text-3xl">
             {formatMinutesDuration(totals.baseMinutes)}
           </p>
         </div>
-        <div className="rounded-xl border border-neutral-200 bg-white p-4 shadow-sm dark:border-midnight-800 dark:bg-midnight-900 sm:p-5">
-          <p className="text-[10px] uppercase tracking-wide text-neutral-500 sm:text-xs">Penalty hours</p>
+        <div className={metricCardClass}>
+          <p className={metricLabelClass}>Penalty hours</p>
           <p className="text-xl font-semibold leading-tight text-neutral-900 dark:text-neutral-50 sm:text-3xl">
             {formatMinutesDuration(totals.penaltyMinutes)}
           </p>
         </div>
-        <div className="rounded-xl border border-neutral-200 bg-white p-4 shadow-sm dark:border-midnight-800 dark:bg-midnight-900 sm:p-5">
-          <p className="text-[10px] uppercase tracking-wide text-neutral-500 sm:text-xs">Total pay</p>
+        <div className={metricCardClass}>
+          <p className={metricLabelClass}>Gross pay</p>
           <p className="text-xl font-semibold leading-tight text-neutral-900 dark:text-neutral-50 sm:text-3xl">
             {currencyFormatter.format(totalPay / 100)}
           </p>
-        </div>
-        <div className="rounded-xl border border-neutral-200 bg-white p-4 shadow-sm dark:border-midnight-800 dark:bg-midnight-900 sm:p-5">
-          <p className="text-[10px] uppercase tracking-wide text-neutral-500 sm:text-xs">Tax withheld</p>
-          <p className="text-xl font-semibold leading-tight text-neutral-900 dark:text-neutral-50 sm:text-3xl">
-            {currencyFormatter.format(totalWithheld / 100)}
+          <p className={metricDetailClass}>
+            Tax withheld: {currencyFormatter.format(totalWithheld / 100)}
           </p>
         </div>
-        <div className="rounded-xl border border-neutral-200 bg-white p-4 shadow-sm dark:border-midnight-800 dark:bg-midnight-900 sm:p-5">
-          <p className="text-[10px] uppercase tracking-wide text-neutral-500 sm:text-xs">Take-home pay</p>
+        <div className={metricCardClass}>
+          <p className={metricLabelClass}>Take-home pay</p>
           <p className="text-xl font-semibold leading-tight text-neutral-900 dark:text-neutral-50 sm:text-3xl">
             {currencyFormatter.format(totalTakeHome / 100)}
+          </p>
+          <p className={metricDetailClass}>
+            {hasWithholding
+              ? `Net after ${currencyFormatter.format(totalWithheld / 100)} withheld`
+              : 'All pay recorded as take-home'}
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- remove tax withholding details from the shifts calendar cards, detail modal, and reusable shift card component
- refactor the summary metrics grid so tax withholding fits within the responsive layout across breakpoints

## Testing
- npm run lint *(fails: existing lint warnings/errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68def3c64be88331b2649f91a8558bd4