### PR TITLE
Restore expected copy for summary and shifts empty states

### DIFF
--- a/src/app/routes/ShiftsPage.tsx
+++ b/src/app/routes/ShiftsPage.tsx
@@ -226,7 +226,7 @@ export default function ShiftsPage() {
         </div>
       </header>
 
-      {isLoading && <p className="text-sm text-neutral-500">Chrona is preparing your calendar…</p>}
+      {isLoading && <p className="text-sm text-neutral-500">Chrona is preparing your calendar...</p>}
 
       <div className="grid min-h-[70vh] grid-rows-[minmax(0,1fr)_minmax(0,1fr)] gap-4 sm:flex sm:flex-col">
         <div className="overflow-x-auto sm:overflow-visible">
@@ -369,7 +369,7 @@ export default function ShiftsPage() {
 
       {!isLoading && shifts.length === 0 && (
         <p className="text-sm text-neutral-500 dark:text-neutral-300">
-          Chrona hasn’t logged any shifts yet.
+          Chrona hasn't logged any shifts yet.
         </p>
       )}
 

--- a/src/app/routes/SummaryPage.tsx
+++ b/src/app/routes/SummaryPage.tsx
@@ -104,7 +104,7 @@ export default function SummaryPage() {
           </p>
         </div>
         <div className={metricCardClass}>
-          <p className={metricLabelClass}>Gross pay</p>
+          <p className={metricLabelClass}>Total pay</p>
           <p className="text-xl font-semibold leading-tight text-neutral-900 dark:text-neutral-50 sm:text-3xl">
             {currencyFormatter.format(totalPay / 100)}
           </p>
@@ -133,7 +133,7 @@ export default function SummaryPage() {
         <h2 className="text-lg font-semibold text-neutral-800 dark:text-neutral-100">Shifts</h2>
         {isLoading && <p className="text-sm text-neutral-500">Chrona is syncing your shifts…</p>}
         {!isLoading && shifts.length === 0 && (
-          <p className="text-sm text-neutral-500">Chrona hasn’t recorded any shifts for this week yet.</p>
+          <p className="text-sm text-neutral-500">Chrona hasn't recorded any shifts for this week yet.</p>
         )}
         <div className="flex flex-col gap-4">
           {shifts.map((shift) => (


### PR DESCRIPTION
## Summary
- rename the summary card label back to "Total pay" so smoke tests can find the metric
- revert curly apostrophes and ellipsis in summary and shifts empty states to the straight versions expected by the tests

## Testing
- npm test -- --watch=false *(fails: Failed to resolve import "@tax-engine/core" from TaxSettingsScreen.tsx)*
- npx playwright test --grep "summary page" --project=chromium *(fails: missing system dependencies for Chromium)*

------
https://chatgpt.com/codex/tasks/task_e_68def6aa7ed8833180d316ee25f667b9